### PR TITLE
sql.Rows.Next() can return false and at same time store error in lasterr.

### DIFF
--- a/gorp.go
+++ b/gorp.go
@@ -849,11 +849,13 @@ func rawselect(m *DbMap, exec SqlExecutor, i interface{}, query string,
 
 	list := make([]interface{}, 0)
 
-	for true {
+	for {
 		if !rows.Next() {
+			// if error occured return rawselect
 			if rows.Err() != nil {
 				return nil, rows.Err()
 			}
+			// time to exit from outer "for" loop
 			break
 		}
 		v := reflect.New(t)


### PR DESCRIPTION
Take a look at code http://golang.org/src/pkg/database/sql/sql.go?s=23476:23503#L900

`Next()` calls `driver.Rows.Next()` and store returned error into `lasterr` which is accessible via rows.Err() 

It is important to check that value otherwise select will behave just like everything is normal and might skip few rows silently.
