### PR TITLE
Correct SQLite quoting

### DIFF
--- a/dialect.go
+++ b/dialect.go
@@ -96,7 +96,7 @@ func (d SqliteDialect) LastInsertId(res *sql.Result, table *TableMap, exec SqlEx
 }
 
 func (d SqliteDialect) QuoteField(f string) string {
-	return "'" + f + "'"
+	return "`" + f + "`"
 }
 
 ///////////////////////////////////////////////////////


### PR DESCRIPTION
It appears that the change to quote all fields has broken my sample app. 

You can see the ticket here: 
https://github.com/robfig/revel/issues/74

I believe that the correct fix is to QuoteField use backticks, which seems to be officially endorsed (along with brackets) here:
http://www.sqlite.org/lang_keywords.html
