### PR TITLE
Field tags now allow you to declare a primary key or autoincrement field

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,10 @@ type Person struct {
 //   table.ColMap("Price").Rename("unit_price")
 //   table.ColMap("IgnoreMe").SetTransient(true)
 //
+// the optional flags indicate if the field is a primary key (pk) and/or is an autoincrement field
+// this allows you to go declaratively when doing an AddTableWithName instead of using SetKeys
 type Product struct {
-    Id         int64     `db:"product_id"`
+    Id         int64     `db:"product_id" flags:"pk, autoincrement"`
     Price      int64     `db:"unit_price"`
     IgnoreMe   string    `db:"-"`
 }

--- a/gorp.go
+++ b/gorp.go
@@ -259,7 +259,7 @@ func (t *TableMap) bindInsert(elem reflect.Value) (bindInstance, error) {
 
 		s := bytes.Buffer{}
 		s2 := bytes.Buffer{}
-		s.WriteString(fmt.Sprintf("insert into %s (", t.dbmap.Dialect.QuoteField(t.TableName)))
+		s.WriteString(fmt.Sprintf("insert into %s (", t.TableName))
 
 		x := 0
 		first := true
@@ -311,7 +311,9 @@ func (t *TableMap) bindUpdate(elem reflect.Value) (bindInstance, error) {
 	if plan.query == "" {
 
 		s := bytes.Buffer{}
-		s.WriteString(fmt.Sprintf("update %s set ", t.dbmap.Dialect.QuoteField(t.TableName)))
+		s.WriteString("update ")
+		s.WriteString(t.TableName)
+		s.WriteString(" set ")
 		x := 0
 
 		for y := range t.columns {
@@ -369,7 +371,8 @@ func (t *TableMap) bindDelete(elem reflect.Value) (bindInstance, error) {
 	if plan.query == "" {
 
 		s := bytes.Buffer{}
-		s.WriteString(fmt.Sprintf("delete from %s", t.dbmap.Dialect.QuoteField(t.TableName)))
+		s.WriteString("delete from ")
+		s.WriteString(t.TableName)
 
 		for y := range t.columns {
 			col := t.columns[y]
@@ -597,13 +600,34 @@ func (m *DbMap) AddTableWithName(i interface{}, name string) *TableMap {
 			columnName = f.Name
 		}
 
+		isAuto := false
+		pk := false
+		sfl := f.Tag.Get("flags")
+		if sfl != "" {
+			fl := strings.Split(sfl, ",")
+			for _, v := range fl {
+				fkey := strings.ToUpper(strings.TrimSpace(v))
+				switch fkey {
+				case "PK":
+					pk = true
+				case "AUTOINCREMENT":
+					isAuto = true
+				}
+			}
+		}
+
 		cm := &ColumnMap{
 			ColumnName: columnName,
 			Transient:  columnName == "-",
 			fieldName:  f.Name,
 			gotype:     f.Type,
+			isPK:       pk,
+			isAutoIncr: isAuto,
 		}
 		tmap.columns = append(tmap.columns, cm)
+		if pk {
+			tmap.keys = append(tmap.keys, cm)
+		}		
 		if cm.fieldName == "Version" {
 			tmap.version = tmap.columns[len(tmap.columns)-1]
 		}
@@ -624,7 +648,7 @@ func (m *DbMap) CreateTables() error {
 		table := m.tables[i]
 
 		s := bytes.Buffer{}
-		s.WriteString(fmt.Sprintf("create table %s (", m.Dialect.QuoteField(table.TableName)))
+		s.WriteString(fmt.Sprintf("create table %s (", table.TableName))
 		x := 0
 		for _, col := range table.columns {
 			if !col.Transient {
@@ -677,7 +701,7 @@ func (m *DbMap) DropTables() error {
 	var err error
 	for i := range m.tables {
 		table := m.tables[i]
-		_, e := m.Exec(fmt.Sprintf("drop table %s;", m.Dialect.QuoteField(table.TableName)))
+		_, e := m.Exec(fmt.Sprintf("drop table %s;", table.TableName))
 		if e != nil {
 			err = e
 		}
@@ -1407,3 +1431,7 @@ func lockError(m *DbMap, exec SqlExecutor, tableName string,
 	}
 	return -1, ole
 }
+
+
+
+


### PR DESCRIPTION
With this patch you can declaratively say:

type Product struct {
    Id         int64     `db:"product_id" flags:"pk, autoincrement"`
    Price      int64     `db:"unit_price"`
    IgnoreMe   string    `db:"-"`
}

so that your AddTableWithName will be simpler like:
t1 := dbmap.AddTableWithName(Invoice{}, "invoice_test")

instead of using SetKeys to specify keys on fields.