### PR TITLE
CreateTableOpts(): create tables with additional options (ie "IF NOT EXISTS")

### DIFF
--- a/gorp.go
+++ b/gorp.go
@@ -619,12 +619,20 @@ func (m *DbMap) AddTableWithName(i interface{}, name string) *TableMap {
 // This is particularly useful in unit tests where you want to create
 // and destroy the schema automatically.
 func (m *DbMap) CreateTables() error {
+	return m.CreateTablesOpts(false)
+}
+
+func (m *DbMap) CreateTablesOpts(ifNotExists bool) error {
 	var err error
 	for i := range m.tables {
 		table := m.tables[i]
 
+		create := "create table"
+		if ifNotExists {
+			create += " if not exists"
+		}
 		s := bytes.Buffer{}
-		s.WriteString(fmt.Sprintf("create table %s (", m.Dialect.QuoteField(table.TableName)))
+		s.WriteString(fmt.Sprintf("%s %s (", create, m.Dialect.QuoteField(table.TableName)))
 		x := 0
 		for _, col := range table.columns {
 			if !col.Transient {


### PR DESCRIPTION
I couldn't find a way to create gorp tables with the "IF NOT EXISTS" modifier. 
- I renamed CreateTables() to CreateTablesOpt(), and added a bool argument to specify whether IF NOT EXISTS should be used.
- CreateTables() is now a wrapper around CreatTablesOpt(). Its behavior is unchanged.

I have only tested this on SQlite.
