### PR TITLE
Support nested fields in embedded structs

### DIFF
--- a/gorp_test.go
+++ b/gorp_test.go
@@ -606,6 +606,11 @@ func TestWithEmbeddedStruct(t *testing.T) {
 	if !reflect.DeepEqual(expected, es2) {
 		t.Errorf("%v != %v", expected, es2)
 	}
+
+	ess := rawselect(dbmap, WithEmbeddedStruct{}, "select * from embedded_struct_test")
+	if !reflect.DeepEqual(es2, ess[0]) {
+		t.Errorf("%v != %v", es2, ess[0])
+	}
 }
 
 func TestSelectVal(t *testing.T) {


### PR DESCRIPTION
Adds support for nested fields in embedded structs.

For example, you can map `WithEmbeddedStruct` below to a table. Embedded structs are flattened so that all nested fields exist at the same level in the database. The table for `WithEmbeddedStruct` will have columns id, first_name, and last_name. 

``` go
type WithEmbeddedStruct struct {
    Id int64
    Names
}

type Names struct {
    FirstName string
    LastName  string
}

```

I have confirmed it passes the tests on PostgreSQL and SQLite. I don't have MySQL set up to test it, but this seems like a DB-agnostic change.

Fixes https://github.com/coopernurse/gorp/issues/9.
