### PR TITLE
Panic when the user requests an auto-inc pkey with multiple cols

### DIFF
--- a/gorp.go
+++ b/gorp.go
@@ -148,6 +148,11 @@ func (t *TableMap) ResetSql() {
 //
 // Automatically calls ResetSql() to ensure SQL statements are regenerated.
 func (t *TableMap) SetKeys(isAutoIncr bool, fieldNames ...string) *TableMap {
+	if isAutoIncr && len(fieldNames) > 1 {
+		panic(fmt.Sprintf(
+			"Multi-column primary keys cannot auto-increment. (Saw %v columns)",
+			len(fieldNames)))
+	}
 	t.keys = make([]*ColumnMap, 0)
 	for _, name := range fieldNames {
 		colmap := t.ColMap(name)


### PR DESCRIPTION
Setting auto-increment for a multi-column primary key presently fails
silently; this makes it fail loudly.

A better fix would be to figure out where/why the silent failure occurs.
