### PR TITLE
Add Select* helper interface methods to SqlExecutor

### DIFF
--- a/gorp.go
+++ b/gorp.go
@@ -550,6 +550,10 @@ type SqlExecutor interface {
 	queryRow(query string, args ...interface{}) *sql.Row
 }
 
+// Compile-time check that DbMap and Transaction implement the SqlExecutor
+// interface.
+var _, _ SqlExecutor = &DbMap{}, &Transaction{}
+
 // TraceOn turns on SQL statement logging for this DbMap.  After this is
 // called, all SQL statements will be sent to the logger.  If prefix is
 // a non-empty string, it will be written to the front of all logged


### PR DESCRIPTION
This PR adds `SelectInt`, `SelectNullInt`, `SelectStr`, and `SelectNullStr` methods to the `SqlExecutor` interface. This is useful when you want to write code that can take either a `DbMap` or `Transaction` and that uses one of these helper methods.

It's possible you left these out of the original interface pending another refactor, to avoid breaking API compat. In that case, we can certainly live without these changes; they are conveniences more than anything else (since we can always call `SelectNullStr(SqlExecutor, ...)`).

@ottob +1'd this: https://github.com/sqs/gorp/commit/c9c25a8f56cff5b9133231607136c62f8f9cd119#commitcomment-3485414
