### PR TITLE
Add TruncateTables() functionality

### DIFF
--- a/dialect.go
+++ b/dialect.go
@@ -29,6 +29,9 @@ type Dialect interface {
 	// table attributes
 	CreateTableSuffix() string
 
+	// string to truncate tables
+	TruncateClause() string
+
 	InsertAutoIncr(exec SqlExecutor, insertSql string, params ...interface{}) (int64, error)
 
 	// bind variable string to use when forming SQL statements
@@ -108,6 +111,13 @@ func (d SqliteDialect) CreateTableSuffix() string {
 	return d.suffix
 }
 
+// With sqlite, there technically isn't a TRUNCATE statement,
+// but a DELETE FROM uses a truncate optimization:
+// http://www.sqlite.org/lang_delete.html
+func (d SqliteDialect) TruncateClause() string {
+	return "delete from"
+}
+
 // Returns "?"
 func (d SqliteDialect) BindVar(i int) string {
 	return "?"
@@ -184,6 +194,10 @@ func (d PostgresDialect) AutoIncrInsertSuffix(col *ColumnMap) string {
 // Returns suffix
 func (d PostgresDialect) CreateTableSuffix() string {
 	return d.suffix
+}
+
+func (d PostgresDialect) TruncateClause() string {
+	return "truncate"
 }
 
 // Returns "$(i+1)"
@@ -274,6 +288,10 @@ func (m MySQLDialect) AutoIncrInsertSuffix(col *ColumnMap) string {
 // Returns engine=%s charset=%s  based on values stored on struct
 func (m MySQLDialect) CreateTableSuffix() string {
 	return fmt.Sprintf(" engine=%s charset=%s", m.Engine, m.Encoding)
+}
+
+func (m MySQLDialect) TruncateClause() string {
+	return "truncate"
 }
 
 // Returns "?"

--- a/gorp.go
+++ b/gorp.go
@@ -745,6 +745,22 @@ func (m *DbMap) dropTables(addIfExists bool) error {
 	return err
 }
 
+// TruncateTables iterates through TableMaps registered to this DbMap and
+// executes "truncate table" statements against the database for each, or in the case of
+// sqlite, a "delete from" with no "where" clause, which uses the truncate optimization
+// (http://www.sqlite.org/lang_delete.html)
+func (m *DbMap) TruncateTables() error {
+	var err error
+	for i := range m.tables {
+		table := m.tables[i]
+		_, e := m.Exec(fmt.Sprintf("%s %s;", m.Dialect.TruncateClause(), m.Dialect.QuoteField(table.TableName)))
+		if e != nil {
+			err = e
+		}
+	}
+	return err
+}
+
 // Insert runs a SQL INSERT statement for each element in list.  List
 // items must be pointers.
 //

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -199,6 +199,36 @@ func TestCreateTablesIfNotExists(t *testing.T) {
 	}
 }
 
+func TestTruncateTables(t *testing.T) {
+	dbmap := initDbMap()
+	defer dbmap.DropTables()
+	err := dbmap.CreateTablesIfNotExists()
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Insert some data
+	p1 := &Person{0, 0, 0, "Bob", "Smith", 0}
+	dbmap.Insert(p1)
+	inv := &Invoice{0, 0, 1, "my invoice", 0, true}
+	dbmap.Insert(inv)
+
+	err = dbmap.TruncateTables()
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Make sure all rows are deleted
+	rows, _ := dbmap.Select(Person{}, "SELECT * FROM person_test")
+	if len(rows) != 0 {
+		t.Errorf("Expected 0 person rows, got %d", len(rows))
+	}
+	rows, _ = dbmap.Select(Invoice{}, "SELECT * FROM invoice_test")
+	if len(rows) != 0 {
+		t.Errorf("Expected 0 invoice rows, got %d", len(rows))
+	}
+}
+
 func TestUIntPrimaryKey(t *testing.T) {
 	dbmap := newDbMap()
 	dbmap.TraceOn("", log.New(os.Stdout, "gorptest: ", log.Lmicroseconds))

--- a/sql_test.go
+++ b/sql_test.go
@@ -16,11 +16,11 @@ func connectDb() *sql.DB {
 
 // This fails on my machine with:
 //
-// panic: Received #1461 error from MySQL server: 
-// "Can't create more than max_prepared_stmt_count statements 
+// panic: Received #1461 error from MySQL server:
+// "Can't create more than max_prepared_stmt_count statements
 // (current value: 16382)"
 //
-// Cause: stmt.Exec() is opening a new db connection for each call 
+// Cause: stmt.Exec() is opening a new db connection for each call
 // because each connection is still considered in use
 //
 func _TestPrepareExec(t *testing.T) {


### PR DESCRIPTION
Hi James,

I found truncating all my tables to be useful in unit testing when using Revel, instead of having to create and drop databases all the time. I added the functionality to dbmap, and added tests (works on all dialects). Hope you find this useful!
