### PR TITLE
Adds support for SAVEPOINT, ROLLBACK TO SAVEPOINT, and RELEASE SAVEPOINT

### DIFF
--- a/gorp.go
+++ b/gorp.go
@@ -1034,6 +1034,36 @@ func (t *Transaction) Rollback() error {
 	return t.tx.Rollback()
 }
 
+// Savepoint creates a savepoint with the given name. The name is interpolated
+// directly into the SQL SAVEPOINT statement, so you must sanitize it if it is
+// derived from user input.
+func (t *Transaction) Savepoint(name string) error {
+	query := "savepoint " + t.dbmap.Dialect.QuoteField(name)
+	t.dbmap.trace(query, nil)
+	_, err := t.tx.Exec(query)
+	return err
+}
+
+// RollbackToSavepoint rolls back to the savepoint with the given name. The
+// name is interpolated directly into the SQL SAVEPOINT statement, so you must
+// sanitize it if it is derived from user input.
+func (t *Transaction) RollbackToSavepoint(savepoint string) error {
+	query := "rollback to savepoint " + t.dbmap.Dialect.QuoteField(savepoint)
+	t.dbmap.trace(query, nil)
+	_, err := t.tx.Exec(query)
+	return err
+}
+
+// ReleaseSavepint releases the savepoint with the given name. The name is
+// interpolated directly into the SQL SAVEPOINT statement, so you must sanitize
+// it if it is derived from user input.
+func (t *Transaction) ReleaseSavepoint(savepoint string) error {
+	query := "release savepoint " + t.dbmap.Dialect.QuoteField(savepoint)
+	t.dbmap.trace(query, nil)
+	_, err := t.tx.Exec(query)
+	return err
+}
+
 func (t *Transaction) queryRow(query string, args ...interface{}) *sql.Row {
 	t.dbmap.trace(query, args)
 	return t.tx.QueryRow(query, args...)


### PR DESCRIPTION
Passes tests in all 3 DB engines.

PostgreSQL (and possibly others) won't accept savepoint names as bind vars, so they are interpolated directly. Savepoints rarely come from user input and the function docs warn against using savepoint names derived from user input, but it's very possible that a developer could slip up. Any suggestions?
