### PR TITLE
Use fmt.Errorf(...) instead of errors.New(fmt.Sprintf(...)).

### DIFF
--- a/gorp.go
+++ b/gorp.go
@@ -1357,7 +1357,7 @@ func toType(i interface{}) (reflect.Type, error) {
 	}
 
 	if t.Kind() != reflect.Struct {
-		return nil, errors.New(fmt.Sprintf("gorp: Cannot SELECT into non-struct type: %v", reflect.TypeOf(i)))
+		return nil, fmt.Errorf("gorp: Cannot SELECT into non-struct type: %v", reflect.TypeOf(i))
 	}
 	return t, nil
 }
@@ -1545,7 +1545,7 @@ func insert(m *DbMap, exec SqlExecutor, list ...interface{}) error {
 			} else if (k == reflect.Uint16) || (k == reflect.Uint32) || (k == reflect.Uint64) {
 				f.SetUint(uint64(id))
 			} else {
-				return errors.New(fmt.Sprintf("gorp: Cannot set autoincrement value on non-Int field. SQL=%s  autoIncrIdx=%d", bi.query, bi.autoIncrIdx))
+				return fmt.Errorf("gorp: Cannot set autoincrement value on non-Int field. SQL=%s  autoIncrIdx=%d", bi.query, bi.autoIncrIdx)
 			}
 		} else {
 			_, err := exec.Exec(bi.query, bi.args...)

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -148,7 +148,7 @@ func (p *Person) PreInsert(s SqlExecutor) error {
 	p.Created = time.Now().UnixNano()
 	p.Updated = p.Created
 	if p.FName == "badname" {
-		return errors.New(fmt.Sprintf("Invalid name: %s", p.FName))
+		return fmt.Errorf("Invalid name: %s", p.FName)
 	}
 	return nil
 }


### PR DESCRIPTION
Just a small thing: fmt.Errorf(...) can be used as a shorthand for errors.New(fmt.Sprintf(...)).  Changing this makes golint (found at github.com/golang/lint) a bit happier.
