### PR TITLE
Add named query parameter binding from map or struct.

### DIFF
--- a/gorp_test.go
+++ b/gorp_test.go
@@ -1016,6 +1016,16 @@ func TestSelectVal(t *testing.T) {
 	if !reflect.DeepEqual(ns, sql.NullString{"", false}) {
 		t.Errorf("nullstr no rows %v != '',false", ns)
 	}
+
+	// SelectInt/Str with named parameters
+	i64 = selectInt(dbmap, "select Int64 from TableWithNull where Str=:abc", map[string]string{"abc": "abc"})
+	if i64 != 78 {
+		t.Errorf("int64 %d != 78", i64)
+	}
+	ns = selectNullStr(dbmap, "select Str from TableWithNull where Int64=:num", map[string]int{"num": 78})
+	if !reflect.DeepEqual(ns, sql.NullString{"abc", true}) {
+		t.Errorf("nullstr %v != abc,true", ns)
+	}
 }
 
 func TestVersionMultipleRows(t *testing.T) {


### PR DESCRIPTION
Fixes #61 
Tested on mysql.

Allows selects like the following examples:

``` go
dbm.Select(&dest, "select * from Foo where name = :name and age = :age", map[string]interface{}{
  "name": "Rob", 
  "age": 31,
})

rob := Person{Name: "Rob", Age: 31}
dbm.Select(&dest, "select * from Foo where name = :Name and age = :Age", rob)
```

Notes:
- Struct: "db" tags are ignored.  Keys should be named exactly as they appear in the struct.  
- The argument type is flexible.  Maps need string keys, but they can have any value type.  Structs can be pointer or non-pointer. 

I don't believe that maps or structs are currently allowed as query parameters, so I don't think this could possibly break any existing clients.  

Please advise if there are other test cases that you'd like.  (Feels like the tests could use a refactoring sometime soon..) 
