### PR TITLE
Allow callers to get data out in slices of pointers or values

### DIFF
--- a/gorp.go
+++ b/gorp.go
@@ -1209,8 +1209,11 @@ func hookedselect(m *DbMap, exec SqlExecutor, i interface{}, query string,
 
 func rawselect(m *DbMap, exec SqlExecutor, i interface{}, query string,
 	args ...interface{}) ([]interface{}, error) {
-	appendToSlice := false // Write results to i directly?
-	intoStruct := true     // Selecting into a struct?
+	var (
+		appendToSlice   = false // Write results to i directly?
+		intoStruct      = true  // Selecting into a struct?
+		pointerElements = true  // Are the slice elements pointers (vs values)?
+	)
 
 	// get type for i, verifying it's a supported destination
 	t, err := toType(i)
@@ -1221,6 +1224,10 @@ func rawselect(m *DbMap, exec SqlExecutor, i interface{}, query string,
 				return nil, err2
 			}
 			return nil, err
+		}
+		pointerElements = t.Kind() == reflect.Ptr
+		if pointerElements {
+			t = t.Elem()
 		}
 		appendToSlice = true
 		intoStruct = t.Kind() == reflect.Struct
@@ -1301,6 +1308,9 @@ func rawselect(m *DbMap, exec SqlExecutor, i interface{}, query string,
 		}
 
 		if appendToSlice {
+			if !pointerElements {
+				v = v.Elem()
+			}
 			sliceValue.Set(reflect.Append(sliceValue, v))
 		} else {
 			list = append(list, v.Interface())
@@ -1384,7 +1394,7 @@ func fieldByName(val reflect.Value, fieldName string) *reflect.Value {
 }
 
 // toSliceType returns the element type of the given object, if the object is a
-// "*[]*Element". If not, returns nil.
+// "*[]*Element" or "*[]Element". If not, returns nil.
 // err is returned if the user was trying to pass a pointer-to-slice but failed.
 func toSliceType(i interface{}) (reflect.Type, error) {
 	t := reflect.TypeOf(i)
@@ -1398,10 +1408,7 @@ func toSliceType(i interface{}) (reflect.Type, error) {
 	if t = t.Elem(); t.Kind() != reflect.Slice {
 		return nil, nil
 	}
-	for t = t.Elem(); t.Kind() == reflect.Ptr; {
-		t = t.Elem()
-	}
-	return t, nil
+	return t.Elem(), nil
 }
 
 func toType(i interface{}) (reflect.Type, error) {

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -306,6 +306,19 @@ func TestPersistentUser(t *testing.T) {
 		t.Errorf("%v!=%v", pu, puArr[0])
 	}
 
+	// prove we can get the results back in a non-pointer slice
+	var puValues []PersistentUser
+	_, err = dbmap.Select(&puValues, "select * from PersistentUser")
+	if err != nil {
+		panic(err)
+	}
+	if len(puValues) != 1 {
+		t.Errorf("Expected one persistentuser, found none")
+	}
+	if !reflect.DeepEqual(*pu, puValues[0]) {
+		t.Errorf("%v!=%v", *pu, puValues[0])
+	}
+
 	// prove we can get the results back in a string slice
 	var idArr []*string
 	_, err = dbmap.Select(&idArr, "select Id from PersistentUser")
@@ -343,6 +356,19 @@ func TestPersistentUser(t *testing.T) {
 	}
 	if !reflect.DeepEqual(pu.PassedTraining, *passedArr[0]) {
 		t.Errorf("%v!=%v", pu.PassedTraining, *passedArr[0])
+	}
+
+	// prove we can get the results back in a non-pointer slice
+	var stringArr []string
+	_, err = dbmap.Select(&stringArr, "select Id from PersistentUser")
+	if err != nil {
+		panic(err)
+	}
+	if len(stringArr) != 1 {
+		t.Errorf("Expected one persistentuser, found none")
+	}
+	if !reflect.DeepEqual(pu.Id, stringArr[0]) {
+		t.Errorf("%v!=%v", pu.Id, stringArr[0])
 	}
 }
 


### PR DESCRIPTION
This makes it possible to get []string out of gorp instead of the less convenient []*string (and similar cases).
