### PR TITLE
Don't swallow useful PostgreSQL errors when INSERT fails for some reason...

### DIFF
--- a/dialect.go
+++ b/dialect.go
@@ -218,7 +218,7 @@ func (d PostgresDialect) InsertAutoIncr(exec SqlExecutor, insertSql string, para
 		return id, err
 	}
 
-	return 0, errors.New("No serial value returned for insert: " + insertSql)
+	return 0, errors.New("No serial value returned for insert: " + insertSql + " Encountered error: " + rows.Err().Error())
 }
 
 func (d PostgresDialect) QuoteField(f string) string {


### PR DESCRIPTION
Some of my inserts where failing due to not-null constraints. Instead of getting a helpful message, Gorp changed it to an opaque: 

>   No serial value returned for insert: nasty_autogenerated_sql_goes_here

This change will append the low level postgres message, allowing you to actually diagnose the problem.
