### PR TITLE
*added text in case of large maxsize for postgresql

### DIFF
--- a/dialect.go
+++ b/dialect.go
@@ -182,6 +182,8 @@ func (d PostgresDialect) ToSqlType(val reflect.Type, maxsize int, isAutoIncr boo
 
 	if maxsize < 1 {
 		maxsize = 255
+	}else if maxsize >= 4096{
+	      return "text"
 	}
 	return fmt.Sprintf("varchar(%d)", maxsize)
 }


### PR DESCRIPTION
I needed this in my project and it seems like a good standard to me, but you can take it or leave^^ 

if maxsize is greater then 4KB we make the type "text" instead of "varying(x)" on postgres in the hopes of it being more efficient and perhaps a bit more space conscience.
