### PR TITLE
Return a sql.ErrNoRows when SelectOne does not return any row.

### DIFF
--- a/gorp.go
+++ b/gorp.go
@@ -1215,8 +1215,8 @@ func SelectOne(m *DbMap, e SqlExecutor, holder interface{}, query string, args .
 			src := reflect.ValueOf(list[0])
 			dest.Elem().Set(src.Elem())
 		} else {
-			// not found - set pointer to zero val
-			dest.Elem().Set(reflect.Zero(t))
+			// No rows found, return a proper error.
+			return sql.ErrNoRows
 		}
 
 		return nil

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -1281,15 +1281,12 @@ func TestSelectSingleVal(t *testing.T) {
 		t.Error("SelectOne should have returned error for non-pointer holder")
 	}
 
-	// verify that pointer is set to zero val if not found
+	// verify that the error is set to sql.ErrNoRows if not found
 	err = dbmap.SelectOne(&p2, "select * from person_test where Id=:Id", map[string]interface{}{
 		"Id": -2222,
 	})
-	if err != nil {
-		t.Error(err)
-	}
-	if p2.Id != 0 {
-		t.Errorf("p2.Id != 0: %d", p2.Id)
+	if err == nil || err != sql.ErrNoRows {
+		t.Error("SelectOne should have returned an sql.ErrNoRows")
 	}
 
 	_insert(dbmap, &Person{0, 0, 0, "bob", "smith", 0})


### PR DESCRIPTION
The SelectOne wants to return just one row, so it should also return an error
when no rows were returned. In this case, this function will return an
sql.ErrNoRows, as it's done in some functions of the database/sql package (e.g. http://golang.org/pkg/database/sql/#DB.QueryRow).
