### PR TITLE
"MySQLDialect.CreateTableSuffix()" panics with uninitialized fields

### DIFF
--- a/dialect.go
+++ b/dialect.go
@@ -299,6 +299,22 @@ func (m MySQLDialect) AutoIncrInsertSuffix(col *ColumnMap) string {
 
 // Returns engine=%s charset=%s  based on values stored on struct
 func (m MySQLDialect) CreateTableSuffix() string {
+	if m.Engine == "" || m.Encoding == "" {
+		msg := "gorp - undefined"
+
+		if m.Engine == "" {
+			msg += " MySQLDialect.Engine"
+		}
+		if m.Engine == "" && m.Encoding == "" {
+			msg += ","
+		}
+		if m.Encoding == "" {
+			msg += " MySQLDialect.Encoding"
+		}
+		msg += ". Check that your MySQLDialect was correctly initialized when declared."
+		panic(msg)
+	}
+
 	return fmt.Sprintf(" engine=%s charset=%s", m.Engine, m.Encoding)
 }
 


### PR DESCRIPTION
Prior behavior : when using MySQLDialect as a dialect, if one of its fields "Encoding" or "Engine" was not initialized, "dbMap.CreateTable()" would generate an invalid request, and executing it would trigger an error.
The error message would be produced by MySQL :  "ERROR 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '=' "

Proposed behavior : if one of the fields is not initialized (value is empty string), panic when building the query, with a more explicit message : "gorp - uninitialized MySQLDialect.Engine, MySQLDialect.Encoding. Check that your MySQLDialect was correctly initialized when declared."

The panic is triggered in "MySQLDialect.CreateTableSuffix()".
