### PR TITLE
Postgres type of unlimited size is text. 

### DIFF
--- a/dialect.go
+++ b/dialect.go
@@ -180,10 +180,12 @@ func (d PostgresDialect) ToSqlType(val reflect.Type, maxsize int, isAutoIncr boo
 		return "timestamp with time zone"
 	}
 
-	if maxsize < 1 {
-		maxsize = 255
+	if maxsize > 0 {
+		return fmt.Sprintf("varchar(%d)", maxsize)
+	} else {
+		return "text"
 	}
-	return fmt.Sprintf("varchar(%d)", maxsize)
+
 }
 
 // Returns empty string


### PR DESCRIPTION
Using text over varchar is recommended by Postgres community. Adding an length constraint not needed will just lower insert/update performance needing to count length of all fields, and inserts artificial limits.
