### PR TITLE
Fix argument spreading.

### DIFF
--- a/gorp.go
+++ b/gorp.go
@@ -980,7 +980,7 @@ func (m *DbMap) Select(i interface{}, query string, args ...interface{}) ([]inte
 // Exec runs an arbitrary SQL statement.  args represent the bind parameters.
 // This is equivalent to running:  Prepare(), Exec() using database/sql
 func (m *DbMap) Exec(query string, args ...interface{}) (sql.Result, error) {
-	m.trace(query, args)
+	m.trace(query, args...)
 	//stmt, err := m.Db.Prepare(query)
 	//if err != nil {
 	//	return nil, err
@@ -1077,12 +1077,12 @@ func (m *DbMap) tableForPointer(ptr interface{}, checkPK bool) (*TableMap, refle
 }
 
 func (m *DbMap) queryRow(query string, args ...interface{}) *sql.Row {
-	m.trace(query, args)
+	m.trace(query, args...)
 	return m.Db.QueryRow(query, args...)
 }
 
 func (m *DbMap) query(query string, args ...interface{}) (*sql.Rows, error) {
-	m.trace(query, args)
+	m.trace(query, args...)
 	return m.Db.Query(query, args...)
 }
 
@@ -1121,7 +1121,7 @@ func (t *Transaction) Select(i interface{}, query string, args ...interface{}) (
 
 // Exec has the same behavior as DbMap.Exec(), but runs in a transaction.
 func (t *Transaction) Exec(query string, args ...interface{}) (sql.Result, error) {
-	t.dbmap.trace(query, args)
+	t.dbmap.trace(query, args...)
 	stmt, err := t.tx.Prepare(query)
 	if err != nil {
 		return nil, err
@@ -1218,12 +1218,12 @@ func (t *Transaction) ReleaseSavepoint(savepoint string) error {
 }
 
 func (t *Transaction) queryRow(query string, args ...interface{}) *sql.Row {
-	t.dbmap.trace(query, args)
+	t.dbmap.trace(query, args...)
 	return t.tx.QueryRow(query, args...)
 }
 
 func (t *Transaction) query(query string, args ...interface{}) (*sql.Rows, error) {
-	t.dbmap.trace(query, args)
+	t.dbmap.trace(query, args...)
 	return t.tx.Query(query, args...)
 }
 


### PR DESCRIPTION
When gorp forwards bindings into trace() calls, it doesn't apply the spread operator (...). Go then creates an extra slice around the bindings, so in trace(), args is an []interface{} whose 0th index is the actual argument list. I'm not sure if this is intended or not.
