### PR TITLE
error instead of panicing in tableFor

### DIFF
--- a/gorp.go
+++ b/gorp.go
@@ -1037,7 +1037,7 @@ func (m *DbMap) Begin() (*Transaction, error) {
 func (m *DbMap) tableFor(t reflect.Type, checkPK bool) (*TableMap, error) {
 	table := tableOrNil(m, t)
 	if table == nil {
-		panic(fmt.Sprintf("No table found for type: %v", t.Name()))
+		return nil, errors.New(fmt.Sprintf("No table found for type: %v", t.Name()))
 	}
 
 	if checkPK && len(table.keys) < 1 {


### PR DESCRIPTION
Looks like an oversight. 

I was inserting a pointer to a pointer (by accident) and my application was silently failing and reporting a success, due to a `recover` block in the web framework I am using.
