### PR TITLE
Add parameter support for IN (...)

### DIFF
--- a/gorp.go
+++ b/gorp.go
@@ -1581,14 +1581,16 @@ func expandNamedQuery(m *DbMap, query string, keyGetter func(key string) reflect
 	}), args
 }
 
-// List is used to tag slices in a query's argument list
-// whose placeholder should be expanded to reflect the
-// size of the slice. A common example would be:
-// 'select * from t where v in (?)', gorp.List{vals}
+// list is the struct that a group of arguments is actually tagged by
+// so that then can be identified when expanding a query's arguments.
 type list struct {
 	vals []interface{}
 }
 
+// List is used to tag slices in a query's argument list
+// whose placeholder should be expanded to reflect the
+// size of the slice. A common example would be:
+// 'select * from t where v in (?)', gorp.List(vals)
 func List(i ...interface{}) interface{} {
 	return list{i}
 }

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -1436,6 +1436,29 @@ func TestMysqlPanicIfDialectNotInitialized(t *testing.T) {
 	db.CreateTables()
 }
 
+func TestListExpansion(t *testing.T) {
+	dbmap := initDbMap()
+	defer dbmap.DropTables()
+
+	inv1 := &Invoice{0, 100, 200, "a", 0, false}
+	inv2 := &Invoice{0, 100, 200, "b", 0, true}
+	inv3 := &Invoice{0, 100, 200, "c", 0, false}
+	_insert(dbmap, inv1, inv2, inv3)
+
+	var invoices []*Invoice
+	_, err := dbmap.Select(
+		&invoices,
+		"select memo from invoice_test where id in (?)",
+		List{[]interface{}{1, 2, 3}})
+	if err != nil {
+		panic(err)
+	}
+
+	if len(invoices) != 3 {
+		t.Errorf("incorrect number of structs retrieved from database, got %d, expected 3", len(invoices))
+	}
+}
+
 func BenchmarkNativeCrud(b *testing.B) {
 	b.StopTimer()
 	dbmap := initDbMapBench()


### PR DESCRIPTION
Add support for expansion of a slice of values if the slice was tagged wrapped with gorp.List{}. It should be noted that for sqlite this only works if '?' are the only used placeholders.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/coopernurse/gorp/143)

<!-- Reviewable:end -->
