### PR TITLE
Added returning data to a channel of pointers to DbMap.Select()

### DIFF
--- a/README.md
+++ b/README.md
@@ -567,7 +567,7 @@ DSNs for these three databases.
 Support is also provided for:
 
 * Oracle (contributed by @klaidliadon)
-* SQL Server (contributed by @qrawl)
+* SQL Server (contributed by @qrawl) - use driver: github.com/denisenkom/go-mssqldb 
 
 Note that these databases are not covered by CI and I (@coopernurse) have no good way to
 test them locally.  So please try them and send patches as needed, but expect a bit more

--- a/README.md
+++ b/README.md
@@ -564,6 +564,15 @@ implemented per database vendor.  Dialects are provided for:
 Each of these three databases pass the test suite.  See `gorp_test.go` for example 
 DSNs for these three databases.
 
+Support is also provided for:
+
+* Oracle (contributed by @klaidliadon)
+* SQL Server (contributed by @qrawl)
+
+Note that these databases are not covered by CI and I (@coopernurse) have no good way to
+test them locally.  So please try them and send patches as needed, but expect a bit more
+unpredicability.
+
 ## Known Issues ##
 
 ### SQL placeholder portability ###

--- a/dialect.go
+++ b/dialect.go
@@ -294,10 +294,10 @@ type MySQLDialect struct {
 
 func (d MySQLDialect) QuerySuffix() string { return ";" }
 
-func (m MySQLDialect) ToSqlType(val reflect.Type, maxsize int, isAutoIncr bool) string {
+func (d MySQLDialect) ToSqlType(val reflect.Type, maxsize int, isAutoIncr bool) string {
 	switch val.Kind() {
 	case reflect.Ptr:
-		return m.ToSqlType(val.Elem(), maxsize, isAutoIncr)
+		return d.ToSqlType(val.Elem(), maxsize, isAutoIncr)
 	case reflect.Bool:
 		return "boolean"
 	case reflect.Int8:
@@ -342,49 +342,49 @@ func (m MySQLDialect) ToSqlType(val reflect.Type, maxsize int, isAutoIncr bool) 
 }
 
 // Returns auto_increment
-func (m MySQLDialect) AutoIncrStr() string {
+func (d MySQLDialect) AutoIncrStr() string {
 	return "auto_increment"
 }
 
-func (m MySQLDialect) AutoIncrBindValue() string {
+func (d MySQLDialect) AutoIncrBindValue() string {
 	return "null"
 }
 
-func (m MySQLDialect) AutoIncrInsertSuffix(col *ColumnMap) string {
+func (d MySQLDialect) AutoIncrInsertSuffix(col *ColumnMap) string {
 	return ""
 }
 
 // Returns engine=%s charset=%s  based on values stored on struct
-func (m MySQLDialect) CreateTableSuffix() string {
-	if m.Engine == "" || m.Encoding == "" {
+func (d MySQLDialect) CreateTableSuffix() string {
+	if d.Engine == "" || d.Encoding == "" {
 		msg := "gorp - undefined"
 
-		if m.Engine == "" {
+		if d.Engine == "" {
 			msg += " MySQLDialect.Engine"
 		}
-		if m.Engine == "" && m.Encoding == "" {
+		if d.Engine == "" && d.Encoding == "" {
 			msg += ","
 		}
-		if m.Encoding == "" {
+		if d.Encoding == "" {
 			msg += " MySQLDialect.Encoding"
 		}
 		msg += ". Check that your MySQLDialect was correctly initialized when declared."
 		panic(msg)
 	}
 
-	return fmt.Sprintf(" engine=%s charset=%s", m.Engine, m.Encoding)
+	return fmt.Sprintf(" engine=%s charset=%s", d.Engine, d.Encoding)
 }
 
-func (m MySQLDialect) TruncateClause() string {
+func (d MySQLDialect) TruncateClause() string {
 	return "truncate"
 }
 
 // Returns "?"
-func (m MySQLDialect) BindVar(i int) string {
+func (d MySQLDialect) BindVar(i int) string {
 	return "?"
 }
 
-func (m MySQLDialect) InsertAutoIncr(exec SqlExecutor, insertSql string, params ...interface{}) (int64, error) {
+func (d MySQLDialect) InsertAutoIncr(exec SqlExecutor, insertSql string, params ...interface{}) (int64, error) {
 	return standardInsertAutoIncr(exec, insertSql, params...)
 }
 
@@ -405,17 +405,17 @@ func (d MySQLDialect) QuotedTableForQuery(schema string, table string) string {
 ////////////////
 
 // Implementation of Dialect for Microsoft SQL Server databases.
-// Tested on SQL Server 2008.
+// Tested on SQL Server 2008 with driver: github.com/denisenkom/go-mssqldb
 // Presently, it doesn't work with CreateTablesIfNotExists().
 
 type SqlServerDialect struct {
 	suffix string
 }
 
-func (m SqlServerDialect) ToSqlType(val reflect.Type, maxsize int, isAutoIncr bool) string {
+func (d SqlServerDialect) ToSqlType(val reflect.Type, maxsize int, isAutoIncr bool) string {
 	switch val.Kind() {
 	case reflect.Ptr:
-		return m.ToSqlType(val.Elem(), maxsize, isAutoIncr)
+		return d.ToSqlType(val.Elem(), maxsize, isAutoIncr)
 	case reflect.Bool:
 		return "bit"
 	case reflect.Int8:
@@ -462,16 +462,16 @@ func (m SqlServerDialect) ToSqlType(val reflect.Type, maxsize int, isAutoIncr bo
 }
 
 // Returns auto_increment
-func (m SqlServerDialect) AutoIncrStr() string {
+func (d SqlServerDialect) AutoIncrStr() string {
 	return "identity(0,1)"
 }
 
 // Empty string removes autoincrement columns from the INSERT statements.
-func (m SqlServerDialect) AutoIncrBindValue() string {
+func (d SqlServerDialect) AutoIncrBindValue() string {
 	return ""
 }
 
-func (m SqlServerDialect) AutoIncrInsertSuffix(col *ColumnMap) string {
+func (d SqlServerDialect) AutoIncrInsertSuffix(col *ColumnMap) string {
 	return ""
 }
 
@@ -481,16 +481,16 @@ func (d SqlServerDialect) CreateTableSuffix() string {
 	return d.suffix
 }
 
-func (m SqlServerDialect) TruncateClause() string {
+func (d SqlServerDialect) TruncateClause() string {
 	return "delete from"
 }
 
 // Returns "?"
-func (m SqlServerDialect) BindVar(i int) string {
+func (d SqlServerDialect) BindVar(i int) string {
 	return "?"
 }
 
-func (m SqlServerDialect) InsertAutoIncr(exec SqlExecutor, insertSql string, params ...interface{}) (int64, error) {
+func (d SqlServerDialect) InsertAutoIncr(exec SqlExecutor, insertSql string, params ...interface{}) (int64, error) {
 	return standardInsertAutoIncr(exec, insertSql, params...)
 }
 
@@ -504,6 +504,8 @@ func (d SqlServerDialect) QuotedTableForQuery(schema string, table string) strin
 	}
 	return schema + "." + table
 }
+
+func (d SqlServerDialect) QuerySuffix() string { return ";" }
 
 ///////////////////////////////////////////////////////
 // Oracle //

--- a/dialect.go
+++ b/dialect.go
@@ -486,7 +486,7 @@ func (m SqlServerDialect) InsertAutoIncr(exec SqlExecutor, insertSql string, par
 }
 
 func (d SqlServerDialect) QuoteField(f string) string {
-	return f
+	return `"` + f + `"`
 }
 
 func (d SqlServerDialect) QuotedTableForQuery(schema string, table string) string {

--- a/dialect.go
+++ b/dialect.go
@@ -66,7 +66,7 @@ type TargetedAutoIncrInserter interface {
 	// InsertAutoIncrToTarget runs an insert operation and assigns the
 	// resulting automatically generated primary key directly to the
 	// passed in target, which should be a pointer to the primary key
-	// element.
+	// field.
 	InsertAutoIncrToTarget(exec SqlExecutor, insertSql string, target interface{}, params ...interface{}) error
 }
 

--- a/dialect.go
+++ b/dialect.go
@@ -64,9 +64,9 @@ type IntegerAutoIncrInserter interface {
 // for uuids, integers for serials, etc).
 type TargetedAutoIncrInserter interface {
 	// InsertAutoIncrToTarget runs an insert operation and assigns the
-	// resulting automatically generated primary key directly to the
-	// passed in target, which should be a pointer to the primary key
-	// field.
+	// automatically generated primary key directly to the passed in
+	// target.  The target should be a pointer to the primary key
+	// field of the value being inserted.
 	InsertAutoIncrToTarget(exec SqlExecutor, insertSql string, target interface{}, params ...interface{}) error
 }
 

--- a/dialect.go
+++ b/dialect.go
@@ -381,7 +381,10 @@ func (d MySQLDialect) QuoteField(f string) string {
 	return "`" + f + "`"
 }
 
-// MySQL does not have schemas like PostgreSQL does, so just escape it like normal
 func (d MySQLDialect) QuotedTableForQuery(schema string, table string) string {
-	return d.QuoteField(table)
+	if strings.TrimSpace(schema) == "" {
+		return d.QuoteField(table)
+	}
+
+	return schema + "." + d.QuoteField(table)
 }

--- a/gorp.go
+++ b/gorp.go
@@ -1079,6 +1079,9 @@ func (m *DbMap) Begin() (*Transaction, error) {
 	return &Transaction{m, tx, false}, nil
 }
 
+// TableFor returns the *TableMap corresponding to the given Go Type
+// If no table is mapped to that type an error is returned.
+// If checkPK is true and the mapped table has no registered PKs, an error is returned.
 func (m *DbMap) TableFor(t reflect.Type, checkPK bool) (*TableMap, error) {
 	table := tableOrNil(m, t)
 	if table == nil {

--- a/gorp.go
+++ b/gorp.go
@@ -14,12 +14,57 @@ package gorp
 import (
 	"bytes"
 	"database/sql"
+	"database/sql/driver"
 	"errors"
 	"fmt"
 	"reflect"
 	"regexp"
 	"strings"
+	"time"
 )
+
+// Oracle String (empty string is null)
+type OracleString struct {
+	sql.NullString
+}
+
+// Scan implements the Scanner interface.
+func (os *OracleString) Scan(value interface{}) error {
+	if value == nil {
+		os.String, os.Valid = "", false
+		return nil
+	}
+	os.Valid = true
+	return os.NullString.Scan(value)
+}
+
+// Value implements the driver Valuer interface.
+func (os OracleString) Value() (driver.Value, error) {
+	if !os.Valid || os.String == "" {
+		return nil, nil
+	}
+	return os.String, nil
+}
+
+// A nullable Time value
+type NullTime struct {
+	Time  time.Time
+	Valid bool // Valid is true if Time is not NULL
+}
+
+// Scan implements the Scanner interface.
+func (nt *NullTime) Scan(value interface{}) error {
+	nt.Time, nt.Valid = value.(time.Time)
+	return nil
+}
+
+// Value implements the driver Valuer interface.
+func (nt NullTime) Value() (driver.Value, error) {
+	if !nt.Valid {
+		return nil, nil
+	}
+	return nt.Time, nil
+}
 
 var zeroVal reflect.Value
 var versFieldConst = "[gorp_ver_field]"
@@ -340,7 +385,7 @@ func (t *TableMap) bindInsert(elem reflect.Value) (bindInstance, error) {
 		if plan.autoIncrIdx > -1 {
 			s.WriteString(t.dbmap.Dialect.AutoIncrInsertSuffix(t.columns[plan.autoIncrIdx]))
 		}
-		s.WriteString(";")
+		s.WriteString(t.dbmap.Dialect.QuerySuffix())
 
 		plan.query = s.String()
 		t.insertPlan = plan
@@ -398,7 +443,7 @@ func (t *TableMap) bindUpdate(elem reflect.Value) (bindInstance, error) {
 			s.WriteString(t.dbmap.Dialect.BindVar(x))
 			plan.argFields = append(plan.argFields, plan.versField)
 		}
-		s.WriteString(";")
+		s.WriteString(t.dbmap.Dialect.QuerySuffix())
 
 		plan.query = s.String()
 		t.updatePlan = plan
@@ -444,7 +489,7 @@ func (t *TableMap) bindDelete(elem reflect.Value) (bindInstance, error) {
 
 			plan.argFields = append(plan.argFields, plan.versField)
 		}
-		s.WriteString(";")
+		s.WriteString(t.dbmap.Dialect.QuerySuffix())
 
 		plan.query = s.String()
 		t.deletePlan = plan
@@ -485,7 +530,7 @@ func (t *TableMap) bindGet() bindPlan {
 
 			plan.keyFields = append(plan.keyFields, col.fieldName)
 		}
-		s.WriteString(";")
+		s.WriteString(t.dbmap.Dialect.QuerySuffix())
 
 		plan.query = s.String()
 		t.getPlan = plan
@@ -813,7 +858,7 @@ func (m *DbMap) createTables(ifNotExists bool) error {
 		}
 		s.WriteString(") ")
 		s.WriteString(m.Dialect.CreateTableSuffix())
-		s.WriteString(";")
+		s.WriteString(m.Dialect.QuerySuffix())
 		_, err = m.Exec(s.String())
 		if err != nil {
 			break
@@ -1088,8 +1133,33 @@ func (m *DbMap) query(query string, args ...interface{}) (*sql.Rows, error) {
 
 func (m *DbMap) trace(query string, args ...interface{}) {
 	if m.logger != nil {
-		m.logger.Printf("%s%s %v", m.logPrefix, query, args)
+		var margs = argsString(args...)
+		m.logger.Printf("%s%s [%s]", m.logPrefix, query, margs)
 	}
+}
+
+func argsString(args ...interface{}) string {
+	var margs string
+	for i, a := range args {
+		var v interface{} = a
+		if x, ok := v.(driver.Valuer); ok {
+			y, err := x.Value()
+			if err == nil {
+				v = y
+			}
+		}
+		switch v.(type) {
+		case string:
+			v = fmt.Sprintf("%q", v)
+		default:
+			v = fmt.Sprintf("%v", v)
+		}
+		margs += fmt.Sprintf("%d:%s", i+1, v)
+		if i+1 < len(args) {
+			margs += " "
+		}
+	}
+	return margs
 }
 
 ///////////////

--- a/gorp.go
+++ b/gorp.go
@@ -1227,7 +1227,7 @@ func (t *Transaction) query(query string, args ...interface{}) (*sql.Rows, error
 func SelectInt(e SqlExecutor, query string, args ...interface{}) (int64, error) {
 	var h int64
 	err := selectVal(e, &h, query, args...)
-	if err != nil {
+	if err != nil && err != sql.ErrNoRows {
 		return 0, err
 	}
 	return h, nil
@@ -1239,7 +1239,7 @@ func SelectInt(e SqlExecutor, query string, args ...interface{}) (int64, error) 
 func SelectNullInt(e SqlExecutor, query string, args ...interface{}) (sql.NullInt64, error) {
 	var h sql.NullInt64
 	err := selectVal(e, &h, query, args...)
-	if err != nil {
+	if err != nil && err != sql.ErrNoRows {
 		return h, err
 	}
 	return h, nil
@@ -1251,7 +1251,7 @@ func SelectNullInt(e SqlExecutor, query string, args ...interface{}) (sql.NullIn
 func SelectFloat(e SqlExecutor, query string, args ...interface{}) (float64, error) {
 	var h float64
 	err := selectVal(e, &h, query, args...)
-	if err != nil {
+	if err != nil && err != sql.ErrNoRows {
 		return 0, err
 	}
 	return h, nil
@@ -1263,7 +1263,7 @@ func SelectFloat(e SqlExecutor, query string, args ...interface{}) (float64, err
 func SelectNullFloat(e SqlExecutor, query string, args ...interface{}) (sql.NullFloat64, error) {
 	var h sql.NullFloat64
 	err := selectVal(e, &h, query, args...)
-	if err != nil {
+	if err != nil && err != sql.ErrNoRows {
 		return h, err
 	}
 	return h, nil
@@ -1275,7 +1275,7 @@ func SelectNullFloat(e SqlExecutor, query string, args ...interface{}) (sql.Null
 func SelectStr(e SqlExecutor, query string, args ...interface{}) (string, error) {
 	var h string
 	err := selectVal(e, &h, query, args...)
-	if err != nil {
+	if err != nil && err != sql.ErrNoRows {
 		return "", err
 	}
 	return h, nil
@@ -1288,7 +1288,7 @@ func SelectStr(e SqlExecutor, query string, args ...interface{}) (string, error)
 func SelectNullStr(e SqlExecutor, query string, args ...interface{}) (sql.NullString, error) {
 	var h sql.NullString
 	err := selectVal(e, &h, query, args...)
-	if err != nil {
+	if err != nil && err != sql.ErrNoRows {
 		return h, err
 	}
 	return h, nil
@@ -1352,14 +1352,11 @@ func selectVal(e SqlExecutor, holder interface{}, query string, args ...interfac
 	}
 	defer rows.Close()
 
-	if rows.Next() {
-		err = rows.Scan(holder)
-		if err != nil {
-			return err
-		}
+	if !rows.Next() {
+		return sql.ErrNoRows
 	}
 
-	return nil
+	return rows.Scan(holder)
 }
 
 ///////////////

--- a/gorp.go
+++ b/gorp.go
@@ -1865,18 +1865,28 @@ func insert(m *DbMap, exec SqlExecutor, list ...interface{}) error {
 		}
 
 		if bi.autoIncrIdx > -1 {
-			id, err := m.Dialect.InsertAutoIncr(exec, bi.query, bi.args...)
-			if err != nil {
-				return err
-			}
 			f := elem.FieldByName(bi.autoIncrFieldName)
-			k := f.Kind()
-			if (k == reflect.Int) || (k == reflect.Int16) || (k == reflect.Int32) || (k == reflect.Int64) {
-				f.SetInt(id)
-			} else if (k == reflect.Uint16) || (k == reflect.Uint32) || (k == reflect.Uint64) {
-				f.SetUint(uint64(id))
-			} else {
-				return fmt.Errorf("gorp: Cannot set autoincrement value on non-Int field. SQL=%s  autoIncrIdx=%d autoIncrFieldName=%s", bi.query, bi.autoIncrIdx, bi.autoIncrFieldName)
+			switch inserter := m.Dialect.(type) {
+			case IntegerAutoIncrInserter:
+				id, err := inserter.InsertAutoIncr(exec, bi.query, bi.args...)
+				if err != nil {
+					return err
+				}
+				k := f.Kind()
+				if (k == reflect.Int) || (k == reflect.Int16) || (k == reflect.Int32) || (k == reflect.Int64) {
+					f.SetInt(id)
+				} else if (k == reflect.Uint16) || (k == reflect.Uint32) || (k == reflect.Uint64) {
+					f.SetUint(uint64(id))
+				} else {
+					return fmt.Errorf("gorp: Cannot set autoincrement value on non-Int field. SQL=%s  autoIncrIdx=%d autoIncrFieldName=%s", bi.query, bi.autoIncrIdx, bi.autoIncrFieldName)
+				}
+			case TargetedAutoIncrInserter:
+				err := inserter.InsertAutoIncrToTarget(exec, bi.query, f.Addr().Interface(), bi.args...)
+				if err != nil {
+					return err
+				}
+			default:
+				return fmt.Errorf("gorp: Cannot use autoincrement fields on dialects that do not implement an autoincrementing interface")
 			}
 		} else {
 			_, err := exec.Exec(bi.query, bi.args...)

--- a/gorp.go
+++ b/gorp.go
@@ -1372,17 +1372,21 @@ func hookedselect(m *DbMap, exec SqlExecutor, i interface{}, query string,
 	// Determine where the results are: written to i, or returned in list
 	if t, _ := toSliceType(i); t == nil {
 		for _, v := range list {
-			err = runHook("PostGet", reflect.ValueOf(v), hookArg(exec))
-			if err != nil {
-				return nil, err
+			if v, ok := v.(HasPostGet); ok {
+				err := v.PostGet(exec)
+				if err != nil {
+					return nil, err
+				}
 			}
 		}
 	} else {
 		resultsValue := reflect.Indirect(reflect.ValueOf(i))
 		for i := 0; i < resultsValue.Len(); i++ {
-			err = runHook("PostGet", resultsValue.Index(i), hookArg(exec))
-			if err != nil {
-				return nil, err
+			if v, ok := resultsValue.Index(i).Interface().(HasPostGet); ok {
+				err := v.PostGet(exec)
+				if err != nil {
+					return nil, err
+				}
 			}
 		}
 	}
@@ -1730,16 +1734,17 @@ func get(m *DbMap, exec SqlExecutor, i interface{},
 		}
 	}
 
-	err = runHook("PostGet", v, hookArg(exec))
-	if err != nil {
-		return nil, err
+	if v, ok := v.Interface().(HasPostGet); ok {
+		err := v.PostGet(exec)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return v.Interface(), nil
 }
 
 func delete(m *DbMap, exec SqlExecutor, list ...interface{}) (int64, error) {
-	hookarg := hookArg(exec)
 	count := int64(0)
 	for _, ptr := range list {
 		table, elem, err := m.tableForPointer(ptr, true)
@@ -1747,10 +1752,12 @@ func delete(m *DbMap, exec SqlExecutor, list ...interface{}) (int64, error) {
 			return -1, err
 		}
 
-		eptr := elem.Addr()
-		err = runHook("PreDelete", eptr, hookarg)
-		if err != nil {
-			return -1, err
+		eval := elem.Addr().Interface()
+		if v, ok := eval.(HasPreDelete); ok {
+			err = v.PreDelete(exec)
+			if err != nil {
+				return -1, err
+			}
 		}
 
 		bi, err := table.bindDelete(elem)
@@ -1774,9 +1781,11 @@ func delete(m *DbMap, exec SqlExecutor, list ...interface{}) (int64, error) {
 
 		count += rows
 
-		err = runHook("PostDelete", eptr, hookarg)
-		if err != nil {
-			return -1, err
+		if v, ok := eval.(HasPostDelete); ok {
+			err := v.PostDelete(exec)
+			if err != nil {
+				return -1, err
+			}
 		}
 	}
 
@@ -1784,7 +1793,6 @@ func delete(m *DbMap, exec SqlExecutor, list ...interface{}) (int64, error) {
 }
 
 func update(m *DbMap, exec SqlExecutor, list ...interface{}) (int64, error) {
-	hookarg := hookArg(exec)
 	count := int64(0)
 	for _, ptr := range list {
 		table, elem, err := m.tableForPointer(ptr, true)
@@ -1792,10 +1800,12 @@ func update(m *DbMap, exec SqlExecutor, list ...interface{}) (int64, error) {
 			return -1, err
 		}
 
-		eptr := elem.Addr()
-		err = runHook("PreUpdate", eptr, hookarg)
-		if err != nil {
-			return -1, err
+		eval := elem.Addr().Interface()
+		if v, ok := eval.(HasPreUpdate); ok {
+			err = v.PreUpdate(exec)
+			if err != nil {
+				return -1, err
+			}
 		}
 
 		bi, err := table.bindUpdate(elem)
@@ -1824,26 +1834,29 @@ func update(m *DbMap, exec SqlExecutor, list ...interface{}) (int64, error) {
 
 		count += rows
 
-		err = runHook("PostUpdate", eptr, hookarg)
-		if err != nil {
-			return -1, err
+		if v, ok := eval.(HasPostUpdate); ok {
+			err = v.PostUpdate(exec)
+			if err != nil {
+				return -1, err
+			}
 		}
 	}
 	return count, nil
 }
 
 func insert(m *DbMap, exec SqlExecutor, list ...interface{}) error {
-	hookarg := hookArg(exec)
 	for _, ptr := range list {
 		table, elem, err := m.tableForPointer(ptr, false)
 		if err != nil {
 			return err
 		}
 
-		eptr := elem.Addr()
-		err = runHook("PreInsert", eptr, hookarg)
-		if err != nil {
-			return err
+		eval := elem.Addr().Interface()
+		if v, ok := eval.(HasPreInsert); ok {
+			err := v.PreInsert(exec)
+			if err != nil {
+				return err
+			}
 		}
 
 		bi, err := table.bindInsert(elem)
@@ -1872,25 +1885,11 @@ func insert(m *DbMap, exec SqlExecutor, list ...interface{}) error {
 			}
 		}
 
-		err = runHook("PostInsert", eptr, hookarg)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func hookArg(exec SqlExecutor) []reflect.Value {
-	execval := reflect.ValueOf(exec)
-	return []reflect.Value{execval}
-}
-
-func runHook(name string, eptr reflect.Value, arg []reflect.Value) error {
-	hook := eptr.MethodByName(name)
-	if hook != zeroVal {
-		ret := hook.Call(arg)
-		if len(ret) > 0 && !ret[0].IsNil() {
-			return ret[0].Interface().(error)
+		if v, ok := eval.(HasPostInsert); ok {
+			err := v.PostInsert(exec)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -1910,4 +1909,32 @@ func lockError(m *DbMap, exec SqlExecutor, tableName string,
 		ole.RowExists = false
 	}
 	return -1, ole
+}
+
+type HasPostGet interface {
+	PostGet(SqlExecutor) error
+}
+
+type HasPostDelete interface {
+	PostDelete(SqlExecutor) error
+}
+
+type HasPostUpdate interface {
+	PostUpdate(SqlExecutor) error
+}
+
+type HasPostInsert interface {
+	PostInsert(SqlExecutor) error
+}
+
+type HasPreDelete interface {
+	PreDelete(SqlExecutor) error
+}
+
+type HasPreUpdate interface {
+	PreUpdate(SqlExecutor) error
+}
+
+type HasPreInsert interface {
+	PreInsert(SqlExecutor) error
 }

--- a/gorp.go
+++ b/gorp.go
@@ -1911,30 +1911,37 @@ func lockError(m *DbMap, exec SqlExecutor, tableName string,
 	return -1, ole
 }
 
+// PostUpdate() will be executed after the GET statement.
 type HasPostGet interface {
 	PostGet(SqlExecutor) error
 }
 
+// PostUpdate() will be executed after the DELETE statement
 type HasPostDelete interface {
 	PostDelete(SqlExecutor) error
 }
 
+// PostUpdate() will be executed after the UPDATE statement
 type HasPostUpdate interface {
 	PostUpdate(SqlExecutor) error
 }
 
+// PostInsert() will be executed after the INSERT statement
 type HasPostInsert interface {
 	PostInsert(SqlExecutor) error
 }
 
+// PreDelete() will be executed before the DELETE statement.
 type HasPreDelete interface {
 	PreDelete(SqlExecutor) error
 }
 
+// PreUpdate() will be executed before UPDATE statement.
 type HasPreUpdate interface {
 	PreUpdate(SqlExecutor) error
 }
 
+// PreInsert() will be executed before INSERT statement.
 type HasPreInsert interface {
 	PreInsert(SqlExecutor) error
 }

--- a/gorp.go
+++ b/gorp.go
@@ -356,7 +356,7 @@ func (t *TableMap) bindUpdate(elem reflect.Value) (bindInstance, error) {
 
 		for y := range t.columns {
 			col := t.columns[y]
-			if !col.isPK && !col.Transient {
+			if !col.isAutoIncr && !col.Transient {
 				if x > 0 {
 					s.WriteString(", ")
 				}

--- a/gorp.go
+++ b/gorp.go
@@ -1586,14 +1586,16 @@ func columnToFieldIndex(m *DbMap, t reflect.Type, cols []string) ([][]int, error
 	// a field in the i struct
 	for x := range cols {
 		colName := strings.ToLower(cols[x])
-
 		field, found := t.FieldByNameFunc(func(fieldName string) bool {
+			var mappedFieldName string
 			field, _ := t.FieldByName(fieldName)
-			fieldName = field.Tag.Get("db")
-
-			if fieldName == "-" {
+			lowerFieldName := strings.ToLower(field.Name)
+			mappedFieldName = field.Tag.Get("db")
+			if mappedFieldName == "-" && colName != lowerFieldName {
 				return false
-			} else if fieldName == "" {
+			} else if mappedFieldName == "-" && colName == lowerFieldName {
+				return true
+			} else if mappedFieldName == "" {
 				fieldName = field.Name
 			}
 			if tableMapped {
@@ -1602,7 +1604,6 @@ func columnToFieldIndex(m *DbMap, t reflect.Type, cols []string) ([][]int, error
 					fieldName = colMap.ColumnName
 				}
 			}
-
 			return colName == strings.ToLower(fieldName)
 		})
 		if found {

--- a/gorp.go
+++ b/gorp.go
@@ -1667,15 +1667,12 @@ func columnToFieldIndex(m *DbMap, t reflect.Type, cols []string) ([][]int, error
 	for x := range cols {
 		colName := strings.ToLower(cols[x])
 		field, found := t.FieldByNameFunc(func(fieldName string) bool {
-			var mappedFieldName string
 			field, _ := t.FieldByName(fieldName)
-			lowerFieldName := strings.ToLower(field.Name)
-			mappedFieldName = field.Tag.Get("db")
-			if mappedFieldName == "-" && colName != lowerFieldName {
+			fieldName = field.Tag.Get("db")
+
+			if fieldName == "-" {
 				return false
-			} else if mappedFieldName == "-" && colName == lowerFieldName {
-				return true
-			} else if mappedFieldName == "" {
+			} else if fieldName == "" {
 				fieldName = field.Name
 			}
 			if tableMapped {

--- a/gorp.go
+++ b/gorp.go
@@ -168,7 +168,7 @@ type TableMap struct {
 	TableName      string
 	SchemaName     string
 	gotype         reflect.Type
-	columns        []*ColumnMap
+	Columns        []*ColumnMap
 	keys           []*ColumnMap
 	uniqueTogether [][]string
 	version        *ColumnMap
@@ -254,7 +254,7 @@ func (t *TableMap) ColMap(field string) *ColumnMap {
 }
 
 func colMapOrNil(t *TableMap, field string) *ColumnMap {
-	for _, col := range t.columns {
+	for _, col := range t.Columns {
 		if col.fieldName == field || col.ColumnName == field {
 			return col
 		}
@@ -347,8 +347,8 @@ func (t *TableMap) bindInsert(elem reflect.Value) (bindInstance, error) {
 
 		x := 0
 		first := true
-		for y := range t.columns {
-			col := t.columns[y]
+		for y := range t.Columns {
+			col := t.Columns[y]
 			if !(col.isAutoIncr && t.dbmap.Dialect.AutoIncrBindValue() == "") {
 				if !col.Transient {
 					if !first {
@@ -383,7 +383,7 @@ func (t *TableMap) bindInsert(elem reflect.Value) (bindInstance, error) {
 		s.WriteString(s2.String())
 		s.WriteString(")")
 		if plan.autoIncrIdx > -1 {
-			s.WriteString(t.dbmap.Dialect.AutoIncrInsertSuffix(t.columns[plan.autoIncrIdx]))
+			s.WriteString(t.dbmap.Dialect.AutoIncrInsertSuffix(t.Columns[plan.autoIncrIdx]))
 		}
 		s.WriteString(t.dbmap.Dialect.QuerySuffix())
 
@@ -402,8 +402,8 @@ func (t *TableMap) bindUpdate(elem reflect.Value) (bindInstance, error) {
 		s.WriteString(fmt.Sprintf("update %s set ", t.dbmap.Dialect.QuotedTableForQuery(t.SchemaName, t.TableName)))
 		x := 0
 
-		for y := range t.columns {
-			col := t.columns[y]
+		for y := range t.Columns {
+			col := t.Columns[y]
 			if !col.isAutoIncr && !col.Transient {
 				if x > 0 {
 					s.WriteString(", ")
@@ -459,8 +459,8 @@ func (t *TableMap) bindDelete(elem reflect.Value) (bindInstance, error) {
 		s := bytes.Buffer{}
 		s.WriteString(fmt.Sprintf("delete from %s", t.dbmap.Dialect.QuotedTableForQuery(t.SchemaName, t.TableName)))
 
-		for y := range t.columns {
-			col := t.columns[y]
+		for y := range t.Columns {
+			col := t.Columns[y]
 			if !col.Transient {
 				if col == t.version {
 					plan.versField = col.fieldName
@@ -506,7 +506,7 @@ func (t *TableMap) bindGet() bindPlan {
 		s.WriteString("select ")
 
 		x := 0
-		for _, col := range t.columns {
+		for _, col := range t.Columns {
 			if !col.Transient {
 				if x > 0 {
 					s.WriteString(",")
@@ -709,7 +709,7 @@ func (m *DbMap) AddTableWithNameAndSchema(i interface{}, schema string, name str
 	}
 
 	tmap := &TableMap{gotype: t, TableName: name, SchemaName: schema, dbmap: m}
-	tmap.columns, tmap.version = readStructColumns(t)
+	tmap.Columns, tmap.version = readStructColumns(t)
 	m.tables = append(m.tables, tmap)
 
 	return tmap
@@ -810,7 +810,7 @@ func (m *DbMap) createTables(ifNotExists bool) error {
 
 		s.WriteString(fmt.Sprintf("%s %s (", create, m.Dialect.QuotedTableForQuery(table.SchemaName, table.TableName)))
 		x := 0
-		for _, col := range table.columns {
+		for _, col := range table.Columns {
 			if !col.Transient {
 				if x > 0 {
 					s.WriteString(", ")
@@ -1079,7 +1079,7 @@ func (m *DbMap) Begin() (*Transaction, error) {
 	return &Transaction{m, tx, false}, nil
 }
 
-func (m *DbMap) tableFor(t reflect.Type, checkPK bool) (*TableMap, error) {
+func (m *DbMap) TableFor(t reflect.Type, checkPK bool) (*TableMap, error) {
 	table := tableOrNil(m, t)
 	if table == nil {
 		return nil, errors.New(fmt.Sprintf("No table found for type: %v", t.Name()))
@@ -1113,7 +1113,7 @@ func (m *DbMap) tableForPointer(ptr interface{}, checkPK bool) (*TableMap, refle
 	}
 	elem := ptrv.Elem()
 	etype := reflect.TypeOf(elem.Interface())
-	t, err := m.tableFor(etype, checkPK)
+	t, err := m.TableFor(etype, checkPK)
 	if err != nil {
 		return nil, reflect.Value{}, err
 	}
@@ -1765,7 +1765,7 @@ func get(m *DbMap, exec SqlExecutor, i interface{},
 		return nil, err
 	}
 
-	table, err := m.tableFor(t, true)
+	table, err := m.TableFor(t, true)
 	if err != nil {
 		return nil, err
 	}

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -1408,7 +1408,20 @@ func TestSelectSingleVal(t *testing.T) {
 	_insert(dbmap, &Person{0, 0, 0, "bob", "smith", 0})
 	err = dbmap.SelectOne(&p2, "select * from person_test where Fname='bob'")
 	if err == nil {
-		t.Error("Expected nil when two rows found")
+		t.Error("Expected error when two rows found")
+	}
+
+	// tests for #150
+	var tInt int64
+	var tStr string
+	var tBool bool
+	var tFloat float64
+	primVals := []interface{}{tInt, tStr, tBool, tFloat}
+	for _, prim := range primVals {
+		err = dbmap.SelectOne(&prim, "select * from person_test where Id=-123")
+		if err == nil || err != sql.ErrNoRows {
+			t.Error("primVals: SelectOne should have returned sql.ErrNoRows")
+		}
 	}
 }
 

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -11,6 +11,7 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 	_ "github.com/ziutek/mymysql/godrv"
 	"log"
+	"math/rand"
 	"os"
 	"reflect"
 	"strings"
@@ -25,6 +26,11 @@ var _ Dialect = MySQLDialect{}
 var _ Dialect = SqlServerDialect{}
 var _ Dialect = OracleDialect{}
 
+type testable interface {
+	GetId() int64
+	Rand()
+}
+
 type Invoice struct {
 	Id       int64
 	Created  int64
@@ -32,6 +38,41 @@ type Invoice struct {
 	Memo     string
 	PersonId int64
 	IsPaid   bool
+}
+
+func (me *Invoice) GetId() int64 { return me.Id }
+func (me *Invoice) Rand() {
+	me.Memo = fmt.Sprintf("random %d", rand.Int63())
+	me.Created = rand.Int63()
+	me.Updated = rand.Int63()
+}
+
+type InvoiceTag struct {
+	Id       int64 `db:"myid"`
+	Created  int64 `db:"myCreated"`
+	Updated  int64 `db:"date_updated"`
+	Memo     string
+	PersonId int64 `db:"person_id"`
+	IsPaid   bool  `db:"is_Paid"`
+}
+
+func (me *InvoiceTag) GetId() int64 { return me.Id }
+func (me *InvoiceTag) Rand() {
+	me.Memo = fmt.Sprintf("random %d", rand.Int63())
+	me.Created = rand.Int63()
+	me.Updated = rand.Int63()
+}
+
+// See: https://github.com/coopernurse/gorp/issues/175
+type AliasTransientField struct {
+	Id     int64  `db:"id"`
+	Bar    int64  `db:"-"`
+	BarStr string `db:"bar"`
+}
+
+func (me *AliasTransientField) GetId() int64 { return me.Id }
+func (me *AliasTransientField) Rand() {
+	me.BarStr = fmt.Sprintf("random %d", rand.Int63())
 }
 
 type OverriddenInvoice struct {
@@ -71,10 +112,14 @@ type WithIgnoredColumn struct {
 	Created  int64
 }
 
-type IgnoredColumnExported struct {
-	Id       int64
-	External int64 `db:"-"`
-	Created  int64
+type IdCreated struct {
+	Id      int64
+	Created int64
+}
+
+type IdCreatedExternal struct {
+	IdCreated
+	External int64
 }
 
 type WithStringPk struct {
@@ -601,11 +646,9 @@ func TestReturnsNonNilSlice(t *testing.T) {
 }
 
 func TestOverrideVersionCol(t *testing.T) {
-	dbmap := initDbMap()
-	dbmap.DropTables()
+	dbmap := newDbMap()
 	t1 := dbmap.AddTable(InvoicePersonView{}).SetKeys(false, "InvoiceId", "PersonId")
 	err := dbmap.CreateTables()
-
 	if err != nil {
 		panic(err)
 	}
@@ -929,46 +972,71 @@ func TestCrud(t *testing.T) {
 	defer dropAndClose(dbmap)
 
 	inv := &Invoice{0, 100, 200, "first order", 0, true}
+	testCrudInternal(t, dbmap, inv)
+
+	invtag := &InvoiceTag{0, 300, 400, "some order", 33, false}
+	testCrudInternal(t, dbmap, invtag)
+
+	foo := &AliasTransientField{BarStr: "some bar"}
+	testCrudInternal(t, dbmap, foo)
+}
+
+func testCrudInternal(t *testing.T, dbmap *DbMap, val testable) {
+	table, _, err := dbmap.tableForPointer(val, false)
+	if err != nil {
+		t.Errorf("couldn't call TableFor: val=%v err=%v", val, err)
+	}
+
+	_, err = dbmap.Exec("delete from " + table.TableName)
+	if err != nil {
+		t.Errorf("couldn't delete rows from: val=%v err=%v", val, err)
+	}
 
 	// INSERT row
-	_insert(dbmap, inv)
-	if inv.Id == 0 {
-		t.Errorf("inv.Id was not set on INSERT")
+	_insert(dbmap, val)
+	if val.GetId() == 0 {
+		t.Errorf("val.GetId() was not set on INSERT")
 		return
 	}
 
 	// SELECT row
-	obj := _get(dbmap, Invoice{}, inv.Id)
-	inv2 := obj.(*Invoice)
-	if !reflect.DeepEqual(inv, inv2) {
-		t.Errorf("%v != %v", inv, inv2)
+	val2 := _get(dbmap, val, val.GetId())
+	if !reflect.DeepEqual(val, val2) {
+		t.Errorf("%v != %v", val, val2)
 	}
 
 	// UPDATE row and SELECT
-	inv.Memo = "second order"
-	inv.Created = 999
-	inv.Updated = 11111
-	count := _update(dbmap, inv)
+	val.Rand()
+	count := _update(dbmap, val)
 	if count != 1 {
 		t.Errorf("update 1 != %d", count)
 	}
-	obj = _get(dbmap, Invoice{}, inv.Id)
-	inv2 = obj.(*Invoice)
-	if !reflect.DeepEqual(inv, inv2) {
-		t.Errorf("%v != %v", inv, inv2)
+	val2 = _get(dbmap, val, val.GetId())
+	if !reflect.DeepEqual(val, val2) {
+		t.Errorf("%v != %v", val, val2)
+	}
+
+	// Select *
+	rows, err := dbmap.Select(val, "select * from "+table.TableName)
+	if err != nil {
+		t.Errorf("couldn't select * from %s err=%v", table.TableName, err)
+	} else if len(rows) != 1 {
+		t.Errorf("unexpected row count in %s: %d", table.TableName, len(rows))
+	} else if !reflect.DeepEqual(val, rows[0]) {
+		t.Errorf("select * result: %v != %v", val, rows[0])
 	}
 
 	// DELETE row
-	deleted := _del(dbmap, inv)
+	deleted := _del(dbmap, val)
 	if deleted != 1 {
-		t.Errorf("Did not delete row with Id: %d", inv.Id)
+		t.Errorf("Did not delete row with Id: %d", val.GetId())
 		return
 	}
 
 	// VERIFY deleted
-	obj = _get(dbmap, Invoice{}, inv.Id)
-	if obj != nil {
-		t.Errorf("Found invoice with id: %d after Delete()", inv.Id)
+	val2 = _get(dbmap, val, val.GetId())
+	if val2 != nil {
+		t.Errorf("Found invoice with id: %d after Delete()", val.GetId())
 	}
 }
 
@@ -1448,20 +1516,25 @@ func TestSelectAlias(t *testing.T) {
 	dbmap := initDbMap()
 	defer dropAndClose(dbmap)
 
-	p1 := &IgnoredColumnExported{Id: 1, External: 2, Created: 3}
-	_insert(dbmap, p1)
+	p1 := &IdCreatedExternal{IdCreated: IdCreated{Id: 1, Created: 3}, External: 2}
 
-	var p2 IgnoredColumnExported
+	// Insert using embedded IdCreated, which reflects the structure of the table
+	_insert(dbmap, &p1.IdCreated)
 
-	err := dbmap.SelectOne(&p2, "select * from ignored_column_exported_test where Id=1")
+	// Select into IdCreatedExternal type, which includes some fields not present
+	// in id_created_test
+	var p2 IdCreatedExternal
+	err := dbmap.SelectOne(&p2, "select * from id_created_test where Id=1")
 	if err != nil {
 		t.Error(err)
 	}
 	if p2.Id != 1 || p2.Created != 3 || p2.External != 0 {
-		t.Error("Expected ignorred field defaults to not set")
+		t.Error("Expected ignored field defaults to not set")
 	}
 
-	err = dbmap.SelectOne(&p2, "SELECT *, 1 AS external FROM ignored_column_exported_test")
+	// Prove that we can supply an aliased value in the select, and that it will
+	// automatically map to IdCreatedExternal.External
+	err = dbmap.SelectOne(&p2, "SELECT *, 1 AS external FROM id_created_test")
 	if err != nil {
 		t.Error(err)
 	}
@@ -1471,7 +1544,7 @@ func TestSelectAlias(t *testing.T) {
 
 	var rows *sql.Rows
 	var cols []string
-	rows, err = dbmap.Db.Query("SELECT * FROM ignored_column_exported_test")
+	rows, err = dbmap.Db.Query("SELECT * FROM id_created_test")
 	cols, err = rows.Columns()
 	if err != nil || len(cols) != 2 {
 		t.Error("Expected ignored column not created")
@@ -1683,22 +1756,31 @@ func initDbMapBench() *DbMap {
 
 func initDbMap() *DbMap {
 	dbmap := newDbMap()
-	dbmap.TraceOn("", log.New(os.Stdout, "gorptest: ", log.Lmicroseconds))
 	dbmap.AddTableWithName(Invoice{}, "invoice_test").SetKeys(true, "Id")
+	dbmap.AddTableWithName(InvoiceTag{}, "invoice_tag_test").SetKeys(true, "myid")
+	dbmap.AddTableWithName(AliasTransientField{}, "alias_trans_field_test").SetKeys(true, "id")
 	dbmap.AddTableWithName(OverriddenInvoice{}, "invoice_override_test").SetKeys(false, "Id")
 	dbmap.AddTableWithName(Person{}, "person_test").SetKeys(true, "Id")
 	dbmap.AddTableWithName(WithIgnoredColumn{}, "ignored_column_test").SetKeys(true, "Id")
-	dbmap.AddTableWithName(IgnoredColumnExported{}, "ignored_column_exported_test").SetKeys(true, "Id")
+	dbmap.AddTableWithName(IdCreated{}, "id_created_test").SetKeys(true, "Id")
 	dbmap.AddTableWithName(TypeConversionExample{}, "type_conv_test").SetKeys(true, "Id")
 	dbmap.AddTableWithName(WithEmbeddedStruct{}, "embedded_struct_test").SetKeys(true, "Id")
 	dbmap.AddTableWithName(WithEmbeddedStructBeforeAutoincrField{}, "embedded_struct_before_autoincr_test").SetKeys(true, "Id")
 	dbmap.AddTableWithName(WithEmbeddedAutoincr{}, "embedded_autoincr_test").SetKeys(true, "Id")
 	dbmap.AddTableWithName(WithTime{}, "time_test").SetKeys(true, "Id")
 	dbmap.TypeConverter = testTypeConverter{}
-	err := dbmap.CreateTables()
+	err := dbmap.DropTablesIfExists()
 	if err != nil {
 		panic(err)
 	}
+	err = dbmap.CreateTables()
+	if err != nil {
+		panic(err)
+	}
+
+	// See #146 and TestSelectAlias - this type is mapped to the same
+	// table as IdCreated, but includes an extra field that isn't in the table
+	dbmap.AddTableWithName(IdCreatedExternal{}, "id_created_test").SetKeys(true, "Id")
 
 	return dbmap
 }
@@ -1716,7 +1798,9 @@ func initDbMapNulls() *DbMap {
 
 func newDbMap() *DbMap {
 	dialect, driver := dialectAndDriver()
-	return &DbMap{Db: connect(driver), Dialect: dialect}
+	dbmap := &DbMap{Db: connect(driver), Dialect: dialect}
+	dbmap.TraceOn("", log.New(os.Stdout, "gorptest: ", log.Lmicroseconds))
+	return dbmap
 }
 
 func dropAndClose(dbmap *DbMap) {

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -18,6 +18,13 @@ import (
 	"time"
 )
 
+// verify interface compliance
+var _ Dialect = SqliteDialect{}
+var _ Dialect = PostgresDialect{}
+var _ Dialect = MySQLDialect{}
+var _ Dialect = SqlServerDialect{}
+var _ Dialect = OracleDialect{}
+
 type Invoice struct {
 	Id       int64
 	Created  int64

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -306,7 +306,8 @@ func TestSetUniqueTogether(t *testing.T) {
 		t.Error(err)
 	}
 	// "unique" for Postgres/SQLite, "Duplicate entry" for MySQL
-	if !strings.Contains(err.Error(), "unique") && !strings.Contains(err.Error(), "Duplicate entry") {
+	errLower := strings.ToLower(err.Error())
+	if !strings.Contains(errLower, "unique") && !strings.Contains(errLower, "duplicate entry") {
 		t.Error(err)
 	}
 
@@ -317,7 +318,8 @@ func TestSetUniqueTogether(t *testing.T) {
 		t.Error(err)
 	}
 	// "unique" for Postgres/SQLite, "Duplicate entry" for MySQL
-	if !strings.Contains(err.Error(), "unique") && !strings.Contains(err.Error(), "Duplicate entry") {
+	errLower = strings.ToLower(err.Error())
+	if !strings.Contains(errLower, "unique") && !strings.Contains(errLower, "duplicate entry") {
 		t.Error(err)
 	}
 

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -1442,9 +1442,6 @@ func TestChannelSelect(t *testing.T) {
 	dbmap := initDbMap()
 	defer dropAndClose(dbmap)
 
-	bindVar := dbmap.Dialect.BindVar(0)
-	insertStmt := "insert into invoice_test (Memo, PersonId, Created, Updated, IsPaid) values (" +
-		bindVar + ", " + bindVar + ", " + bindVar + ", " + bindVar + ", " + bindVar + ")"
 	query := "select Id, Created, Updated, Memo, PersonId, IsPaid from invoice_test"
 
 	// Build a table with a few rows in to play with
@@ -1455,9 +1452,9 @@ func TestChannelSelect(t *testing.T) {
 		inv.Updated = 200
 		inv.IsPaid = false
 		inv.Memo = "Initial state"
-		_, err := dbmap.Db.Exec(insertStmt, inv.Memo, inv.PersonId, inv.Created, inv.Updated, inv.IsPaid)
+		err := dbmap.Insert(&inv)
 		if err != nil {
-			t.Fatalf("Failed to insert row into test database : %v\n", err)
+			t.Fatalf("Failed to insert invoices into test database : %v\n", err)
 		}
 	}
 

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -1648,7 +1648,44 @@ func TestSingleColumnKeyDbReturnsZeroRowsUpdatedOnPKChange(t *testing.T) {
 	if count != 0 {
 		t.Errorf("Expected 0 updated rows, got %d", count)
 	}
+}
 
+func TestChannelSelect(t *testing.T) {
+	dbInvoiceChan := make(chan *Invoice, 1000)
+	insertStmt := "insert into invoice_test (Memo, PersonId) values (?, ?)"
+	query := "select * from invoice_test"
+	dbmap := initDbMap()
+	defer dropAndClose(dbmap)
+
+	// Build a table with a few rows in to play with
+	for i := 0; i < 1000; i++ {
+		var inv Invoice
+		inv.PersonId = int64(i)
+		inv.Memo = "Initial state"
+		_, err := dbmap.Db.Exec(insertStmt, inv.Memo, inv.PersonId)
+		if err != nil {
+			t.Fatalf("Failed to insert row into test database : %v\n", err)
+		}
+	}
+
+	// Gopher processing the rows as they come out of the database.
+	go func() {
+		var counter int
+		for _ = range dbInvoiceChan {
+			counter++
+		}
+		if counter < 999 {
+			t.Fail()
+		}
+	}()
+
+	// Grab the rows
+	go func() {
+		_, err := dbmap.Select(dbInvoiceChan, query)
+		if err != nil {
+			t.Fail()
+		}
+	}()
 }
 
 func BenchmarkNativeCrud(b *testing.B) {

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -64,6 +64,12 @@ type WithIgnoredColumn struct {
 	Created  int64
 }
 
+type IgnoredColumnExported struct {
+	Id       int64
+	External int64 `db:"-"`
+	Created  int64
+}
+
 type WithStringPk struct {
 	Id   string
 	Name string
@@ -1427,6 +1433,40 @@ func TestSelectSingleVal(t *testing.T) {
 	}
 }
 
+func TestSelectAlias(t *testing.T) {
+	dbmap := initDbMap()
+	defer dropAndClose(dbmap)
+
+	p1 := &IgnoredColumnExported{Id: 1, External: 2, Created: 3}
+	_insert(dbmap, p1)
+
+	var p2 IgnoredColumnExported
+
+	err := dbmap.SelectOne(&p2, "select * from ignored_column_exported_test where Id=1")
+	if err != nil {
+		t.Error(err)
+	}
+	if p2.Id != 1 || p2.Created != 3 || p2.External != 0 {
+		t.Error("Expected ignorred field defaults to not set")
+	}
+
+	err = dbmap.SelectOne(&p2, "SELECT *, 1 AS external FROM ignored_column_exported_test")
+	if err != nil {
+		t.Error(err)
+	}
+	if p2.External != 1 {
+		t.Error("Expected select as can map to exported field.")
+	}
+
+	var rows *sql.Rows
+	var cols []string
+	rows, err = dbmap.Db.Query("SELECT * FROM ignored_column_exported_test")
+	cols, err = rows.Columns()
+	if err != nil || len(cols) != 2 {
+		t.Error("Expected ignored column not created")
+	}
+}
+
 func TestMysqlPanicIfDialectNotInitialized(t *testing.T) {
 	_, driver := dialectAndDriver()
 	// this test only applies to MySQL
@@ -1607,6 +1647,7 @@ func initDbMap() *DbMap {
 	dbmap.AddTableWithName(OverriddenInvoice{}, "invoice_override_test").SetKeys(false, "Id")
 	dbmap.AddTableWithName(Person{}, "person_test").SetKeys(true, "Id")
 	dbmap.AddTableWithName(WithIgnoredColumn{}, "ignored_column_test").SetKeys(true, "Id")
+	dbmap.AddTableWithName(IgnoredColumnExported{}, "ignored_column_exported_test").SetKeys(true, "Id")
 	dbmap.AddTableWithName(TypeConversionExample{}, "type_conv_test").SetKeys(true, "Id")
 	dbmap.AddTableWithName(WithEmbeddedStruct{}, "embedded_struct_test").SetKeys(true, "Id")
 	dbmap.AddTableWithName(WithEmbeddedStructBeforeAutoincrField{}, "embedded_struct_before_autoincr_test").SetKeys(true, "Id")

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -125,6 +125,10 @@ type UniqueColumns struct {
 	ZipCode   int64
 }
 
+type SingleColumnTable struct {
+	SomeId string
+}
+
 type testTypeConverter struct{}
 
 func (me testTypeConverter) ToDb(val interface{}) (interface{}, error) {
@@ -1535,6 +1539,36 @@ func TestChannelSelect(t *testing.T) {
 	}()
 
 	<-completed
+}
+func TestSingleColumnKeyDbReturnsZeroRowsUpdatedOnPKChange(t *testing.T) {
+	dbmap := initDbMap()
+	defer dropAndClose(dbmap)
+	dbmap.AddTableWithName(SingleColumnTable{}, "single_column_table").SetKeys(false, "SomeId")
+	err := dbmap.DropTablesIfExists()
+	if err != nil {
+		t.Error("Drop tables failed")
+	}
+	err = dbmap.CreateTablesIfNotExists()
+	if err != nil {
+		t.Error("Create tables failed")
+	}
+	err = dbmap.TruncateTables()
+	if err != nil {
+		t.Error("Truncate tables failed")
+	}
+
+	sct := SingleColumnTable{
+		SomeId: "A Unique Id String",
+	}
+
+	count, err := dbmap.Update(&sct)
+	if err != nil {
+		t.Error(err)
+	}
+	if count != 0 {
+		t.Errorf("Expected 0 updated rows, got %d", count)
+	}
+
 }
 
 func BenchmarkNativeCrud(b *testing.B) {


### PR DESCRIPTION
Hi,

I have added the capability to pass in a channel (which takes pointers to structs) to the DbMap.Select() method. This enables large tables to be processed in a stream.

Kind regards,
Jon 
