### PR TITLE
Concurrency: race conditions and mutex locks

### DIFF
--- a/gorp.go
+++ b/gorp.go
@@ -176,8 +176,11 @@ type TableMap struct {
 	insertPlan     bindPlan
 	insertPlanMut  sync.Mutex
 	updatePlan     bindPlan
+	updatePlanMut  sync.Mutex
 	deletePlan     bindPlan
+	deletePlanMut  sync.Mutex
 	getPlan        bindPlan
+	getPlanMut  sync.Mutex
 	dbmap          *DbMap
 }
 
@@ -399,6 +402,8 @@ func (t *TableMap) bindInsert(elem reflect.Value) (bindInstance, error) {
 }
 
 func (t *TableMap) bindUpdate(elem reflect.Value) (bindInstance, error) {
+	t.updatePlanMut.Lock()
+	defer t.updatePlanMut.Unlock()
 	plan := t.updatePlan
 	if plan.query == "" {
 
@@ -457,6 +462,8 @@ func (t *TableMap) bindUpdate(elem reflect.Value) (bindInstance, error) {
 }
 
 func (t *TableMap) bindDelete(elem reflect.Value) (bindInstance, error) {
+	t.deletePlanMut.Lock()
+	defer t.deletePlanMut.Unlock()
 	plan := t.deletePlan
 	if plan.query == "" {
 
@@ -503,6 +510,8 @@ func (t *TableMap) bindDelete(elem reflect.Value) (bindInstance, error) {
 }
 
 func (t *TableMap) bindGet() bindPlan {
+		t.getPlanMut.Lock()
+	defer t.getPlanMut.Unlock()
 	plan := t.getPlan
 	if plan.query == "" {
 

--- a/gorp.go
+++ b/gorp.go
@@ -21,6 +21,7 @@ import (
 	"regexp"
 	"strings"
 	"time"
+	"sync"
 )
 
 // Oracle String (empty string is null)
@@ -173,6 +174,7 @@ type TableMap struct {
 	uniqueTogether [][]string
 	version        *ColumnMap
 	insertPlan     bindPlan
+	insertPlanMut  sync.Mutex
 	updatePlan     bindPlan
 	deletePlan     bindPlan
 	getPlan        bindPlan
@@ -337,6 +339,8 @@ type bindInstance struct {
 }
 
 func (t *TableMap) bindInsert(elem reflect.Value) (bindInstance, error) {
+	t.insertPlanMut.Lock()
+	defer t.insertPlanMut.Unlock()
 	plan := t.insertPlan
 	if plan.query == "" {
 		plan.autoIncrIdx = -1


### PR DESCRIPTION
Adding mutex  on every Plan of a table to avoid race condition when using goroutine and Gorp.