### PR TITLE
Oracle diver develop, new method QuerySuffix() in dialect, better args s...

### DIFF
--- a/dialect.go
+++ b/dialect.go
@@ -12,6 +12,9 @@ import (
 // but this could change in the future
 type Dialect interface {
 
+	// adds a suffix to any query, usually ";"
+	QuerySuffix() string
+
 	// ToSqlType returns the SQL column type to use when creating a
 	// table of the given Go Type.  maxsize can be used to switch based on
 	// size.  For example, in MySQL []byte could map to BLOB, MEDIUMBLOB,
@@ -68,6 +71,8 @@ func standardInsertAutoIncr(exec SqlExecutor, insertSql string, params ...interf
 type SqliteDialect struct {
 	suffix string
 }
+
+func (d SqliteDialect) QuerySuffix() string { return ";" }
 
 func (d SqliteDialect) ToSqlType(val reflect.Type, maxsize int, isAutoIncr bool) string {
 	switch val.Kind() {
@@ -152,6 +157,8 @@ func (d SqliteDialect) QuotedTableForQuery(schema string, table string) string {
 type PostgresDialect struct {
 	suffix string
 }
+
+func (d PostgresDialect) QuerySuffix() string { return ";" }
 
 func (d PostgresDialect) ToSqlType(val reflect.Type, maxsize int, isAutoIncr bool) string {
 	switch val.Kind() {
@@ -267,6 +274,8 @@ type MySQLDialect struct {
 	Encoding string
 }
 
+func (d MySQLDialect) QuerySuffix() string { return ";" }
+
 func (m MySQLDialect) ToSqlType(val reflect.Type, maxsize int, isAutoIncr bool) string {
 	switch val.Kind() {
 	case reflect.Ptr:
@@ -368,4 +377,113 @@ func (d MySQLDialect) QuoteField(f string) string {
 // MySQL does not have schemas like PostgreSQL does, so just escape it like normal
 func (d MySQLDialect) QuotedTableForQuery(schema string, table string) string {
 	return d.QuoteField(table)
+}
+
+///////////////////////////////////////////////////////
+// Oracle //
+///////////
+
+// Implementation of Dialect for Oracle databases.
+type OracleDialect struct{}
+
+func (d OracleDialect) QuerySuffix() string { return "" }
+
+func (d OracleDialect) ToSqlType(val reflect.Type, maxsize int, isAutoIncr bool) string {
+	switch val.Kind() {
+	case reflect.Ptr:
+		return d.ToSqlType(val.Elem(), maxsize, isAutoIncr)
+	case reflect.Bool:
+		return "boolean"
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Uint8, reflect.Uint16, reflect.Uint32:
+		if isAutoIncr {
+			return "serial"
+		}
+		return "integer"
+	case reflect.Int64, reflect.Uint64:
+		if isAutoIncr {
+			return "bigserial"
+		}
+		return "bigint"
+	case reflect.Float64:
+		return "double precision"
+	case reflect.Float32:
+		return "real"
+	case reflect.Slice:
+		if val.Elem().Kind() == reflect.Uint8 {
+			return "bytea"
+		}
+	}
+
+	switch val.Name() {
+	case "NullInt64":
+		return "bigint"
+	case "NullFloat64":
+		return "double precision"
+	case "NullBool":
+		return "boolean"
+	case "NullTime", "Time":
+		return "timestamp with time zone"
+	}
+
+	if maxsize > 0 {
+		return fmt.Sprintf("varchar(%d)", maxsize)
+	} else {
+		return "text"
+	}
+
+}
+
+// Returns empty string
+func (d OracleDialect) AutoIncrStr() string {
+	return ""
+}
+
+func (d OracleDialect) AutoIncrBindValue() string {
+	return "default"
+}
+
+func (d OracleDialect) AutoIncrInsertSuffix(col *ColumnMap) string {
+	return " returning " + col.ColumnName
+}
+
+// Returns suffix
+func (d OracleDialect) CreateTableSuffix() string {
+	return ""
+}
+
+func (d OracleDialect) TruncateClause() string {
+	return "truncate"
+}
+
+// Returns "$(i+1)"
+func (d OracleDialect) BindVar(i int) string {
+	return fmt.Sprintf(":%d", i+1)
+}
+
+func (d OracleDialect) InsertAutoIncr(exec SqlExecutor, insertSql string, params ...interface{}) (int64, error) {
+	rows, err := exec.query(insertSql, params...)
+	if err != nil {
+		return 0, err
+	}
+	defer rows.Close()
+
+	if rows.Next() {
+		var id int64
+		err := rows.Scan(&id)
+		return id, err
+	}
+
+	return 0, errors.New("No serial value returned for insert: " + insertSql + " Encountered error: " + rows.Err().Error())
+}
+
+func (d OracleDialect) QuoteField(f string) string {
+	return `"` + strings.ToUpper(f) + `"`
+}
+
+func (d OracleDialect) QuotedTableForQuery(schema string, table string) string {
+	if strings.TrimSpace(schema) == "" {
+		return d.QuoteField(table)
+	}
+
+	return schema + "." + d.QuoteField(table)
 }

--- a/gorp.go
+++ b/gorp.go
@@ -14,12 +14,57 @@ package gorp
 import (
 	"bytes"
 	"database/sql"
+	"database/sql/driver"
 	"errors"
 	"fmt"
 	"reflect"
 	"regexp"
 	"strings"
+	"time"
 )
+
+// Oracle String (empty string is null)
+type OracleString struct {
+	sql.NullString
+}
+
+// Scan implements the Scanner interface.
+func (os *OracleString) Scan(value interface{}) error {
+	if value == nil {
+		os.String, os.Valid = "", false
+		return nil
+	}
+	os.Valid = true
+	return os.NullString.Scan(value)
+}
+
+// Value implements the driver Valuer interface.
+func (os OracleString) Value() (driver.Value, error) {
+	if !os.Valid || os.String == "" {
+		return nil, nil
+	}
+	return os.String, nil
+}
+
+// A nullable Time value
+type NullTime struct {
+	Time  time.Time
+	Valid bool // Valid is true if Time is not NULL
+}
+
+// Scan implements the Scanner interface.
+func (nt *NullTime) Scan(value interface{}) error {
+	nt.Time, nt.Valid = value.(time.Time)
+	return nil
+}
+
+// Value implements the driver Valuer interface.
+func (nt NullTime) Value() (driver.Value, error) {
+	if !nt.Valid {
+		return nil, nil
+	}
+	return nt.Time, nil
+}
 
 var zeroVal reflect.Value
 var versFieldConst = "[gorp_ver_field]"
@@ -337,7 +382,7 @@ func (t *TableMap) bindInsert(elem reflect.Value) (bindInstance, error) {
 		if plan.autoIncrIdx > -1 {
 			s.WriteString(t.dbmap.Dialect.AutoIncrInsertSuffix(t.columns[plan.autoIncrIdx]))
 		}
-		s.WriteString(";")
+		s.WriteString(t.dbmap.Dialect.QuerySuffix())
 
 		plan.query = s.String()
 		t.insertPlan = plan
@@ -395,7 +440,7 @@ func (t *TableMap) bindUpdate(elem reflect.Value) (bindInstance, error) {
 			s.WriteString(t.dbmap.Dialect.BindVar(x))
 			plan.argFields = append(plan.argFields, plan.versField)
 		}
-		s.WriteString(";")
+		s.WriteString(t.dbmap.Dialect.QuerySuffix())
 
 		plan.query = s.String()
 		t.updatePlan = plan
@@ -441,7 +486,7 @@ func (t *TableMap) bindDelete(elem reflect.Value) (bindInstance, error) {
 
 			plan.argFields = append(plan.argFields, plan.versField)
 		}
-		s.WriteString(";")
+		s.WriteString(t.dbmap.Dialect.QuerySuffix())
 
 		plan.query = s.String()
 		t.deletePlan = plan
@@ -482,7 +527,7 @@ func (t *TableMap) bindGet() bindPlan {
 
 			plan.keyFields = append(plan.keyFields, col.fieldName)
 		}
-		s.WriteString(";")
+		s.WriteString(t.dbmap.Dialect.QuerySuffix())
 
 		plan.query = s.String()
 		t.getPlan = plan
@@ -810,7 +855,7 @@ func (m *DbMap) createTables(ifNotExists bool) error {
 		}
 		s.WriteString(") ")
 		s.WriteString(m.Dialect.CreateTableSuffix())
-		s.WriteString(";")
+		s.WriteString(m.Dialect.QuerySuffix())
 		_, err = m.Exec(s.String())
 		if err != nil {
 			break
@@ -1083,8 +1128,33 @@ func (m *DbMap) query(query string, args ...interface{}) (*sql.Rows, error) {
 
 func (m *DbMap) trace(query string, args ...interface{}) {
 	if m.logger != nil {
-		m.logger.Printf("%s%s %v", m.logPrefix, query, args)
+		var margs = argsString(args...)
+		m.logger.Printf("%s%s [%s]", m.logPrefix, query, margs)
 	}
+}
+
+func argsString(args ...interface{}) string {
+	var margs string
+	for i, a := range args {
+		var v interface{} = a
+		if x, ok := v.(driver.Valuer); ok {
+			y, err := x.Value()
+			if err == nil {
+				v = y
+			}
+		}
+		switch v.(type) {
+		case string:
+			v = fmt.Sprintf("%q", v)
+		default:
+			v = fmt.Sprintf("%v", v)
+		}
+		margs += fmt.Sprintf("%d:%s", i+1, v)
+		if i+1 < len(args) {
+			margs += " "
+		}
+	}
+	return margs
 }
 
 ///////////////


### PR DESCRIPTION
I have created an OracleDialect for gorp. I added a method to the dialect interface to add ";" at the end of the string because oracle does not allow queries with with trailing ";".
I also added a NullType for Time and for oracle strings and created and improved the trace with an arguments map and quoted strings.
