### PR TITLE
Adding commented-out failing tests due to golang reflection. (Issue #162)

### DIFF
--- a/gorp_test.go
+++ b/gorp_test.go
@@ -103,6 +103,17 @@ type WithEmbeddedStruct struct {
 	Names
 }
 
+type WithEmbeddedStructConflictingEmbeddedMemberNames struct {
+	Id int64
+	Names
+	NamesConflict
+}
+
+type WithEmbeddedStructSameMemberName struct {
+	Id int64
+	SameName
+}
+
 type WithEmbeddedStructBeforeAutoincrField struct {
 	Names
 	Id int64
@@ -116,6 +127,15 @@ type WithEmbeddedAutoincr struct {
 type Names struct {
 	FirstName string
 	LastName  string
+}
+
+type NamesConflict struct {
+	FirstName string
+	Surname string
+}
+
+type SameName struct {
+	SameName string
 }
 
 type UniqueColumns struct {
@@ -1042,6 +1062,60 @@ func TestWithEmbeddedStruct(t *testing.T) {
 	}
 }
 
+/*
+func TestWithEmbeddedStructConflictingEmbeddedMemberNames(t *testing.T) {
+	dbmap := initDbMap()
+	defer dropAndClose(dbmap)
+
+	es := &WithEmbeddedStructConflictingEmbeddedMemberNames{-1, Names{FirstName: "Alice", LastName: "Smith"}, NamesConflict{FirstName: "Andrew", Surname: "Wiggin"}}
+	_insert(dbmap, es)
+	expected := &WithEmbeddedStructConflictingEmbeddedMemberNames{-1, Names{FirstName: "Alice", LastName: "Smith"}, NamesConflict{FirstName: "Andrew", Surname: "Wiggin"}}
+	es2 := _get(dbmap, WithEmbeddedStructConflictingEmbeddedMemberNames{}, es.Id).(*WithEmbeddedStructConflictingEmbeddedMemberNames)
+	if !reflect.DeepEqual(expected, es2) {
+		t.Errorf("%v != %v", expected, es2)
+	}
+
+	es2.Names.FirstName = "Bob"
+	expected.Names.FirstName = "Bob"
+	_update(dbmap, es2)
+	es2 = _get(dbmap, WithEmbeddedStructConflictingEmbeddedMemberNames{}, es.Id).(*WithEmbeddedStructConflictingEmbeddedMemberNames)
+	if !reflect.DeepEqual(expected, es2) {
+		t.Errorf("%v != %v", expected, es2)
+	}
+
+	ess := _rawselect(dbmap, WithEmbeddedStructConflictingEmbeddedMemberNames{}, "select * from embedded_struct_conflict_name_test")
+	if !reflect.DeepEqual(es2, ess[0]) {
+		t.Errorf("%v != %v", es2, ess[0])
+	}
+}
+
+func TestWithEmbeddedStructSameMemberName(t *testing.T) {
+	dbmap := initDbMap()
+	defer dropAndClose(dbmap)
+
+	es := &WithEmbeddedStructSameMemberName{-1, SameName{SameName: "Alice"}}
+	_insert(dbmap, es)
+	expected := &WithEmbeddedStructSameMemberName{-1, SameName{SameName: "Alice"}}
+	es2 := _get(dbmap, WithEmbeddedStructSameMemberName{}, es.Id).(*WithEmbeddedStructSameMemberName)
+	if !reflect.DeepEqual(expected, es2) {
+		t.Errorf("%v != %v", expected, es2)
+	}
+
+	es2.SameName = SameName{"Bob"}
+	expected.SameName = SameName{"Bob"}
+	_update(dbmap, es2)
+	es2 = _get(dbmap, WithEmbeddedStructSameMemberName{}, es.Id).(*WithEmbeddedStructSameMemberName)
+	if !reflect.DeepEqual(expected, es2) {
+		t.Errorf("%v != %v", expected, es2)
+	}
+
+	ess := _rawselect(dbmap, WithEmbeddedStructSameMemberName{}, "select * from embedded_struct_same_member_name_test")
+	if !reflect.DeepEqual(es2, ess[0]) {
+		t.Errorf("%v != %v", es2, ess[0])
+	}
+}
+//*/
+
 func TestWithEmbeddedStructBeforeAutoincr(t *testing.T) {
 	dbmap := initDbMap()
 	defer dropAndClose(dbmap)
@@ -1639,6 +1713,8 @@ func initDbMap() *DbMap {
 	dbmap.AddTableWithName(IgnoredColumnExported{}, "ignored_column_exported_test").SetKeys(true, "Id")
 	dbmap.AddTableWithName(TypeConversionExample{}, "type_conv_test").SetKeys(true, "Id")
 	dbmap.AddTableWithName(WithEmbeddedStruct{}, "embedded_struct_test").SetKeys(true, "Id")
+	//dbmap.AddTableWithName(WithEmbeddedStructConflictingEmbeddedMemberNames{}, "embedded_struct_conflict_name_test").SetKeys(true, "Id")
+	//dbmap.AddTableWithName(WithEmbeddedStructSameMemberName{}, "embedded_struct_same_member_name_test").SetKeys(true, "Id")
 	dbmap.AddTableWithName(WithEmbeddedStructBeforeAutoincrField{}, "embedded_struct_before_autoincr_test").SetKeys(true, "Id")
 	dbmap.AddTableWithName(WithEmbeddedAutoincr{}, "embedded_autoincr_test").SetKeys(true, "Id")
 	dbmap.AddTableWithName(WithTime{}, "time_test").SetKeys(true, "Id")


### PR DESCRIPTION
As requested in Issue #162, here are two unit tests I used when categorizing the issues I was seeing in golang's reflection. Since that's primarily where the issue lies, the correct way to use reflection as-a-tool and resolve the "shadowing" or "conflicts" is still up for debate. Therefore, the passing criteria for these unit tests is probably still up for debate as well.