### PR TITLE
Added an "upsert" mechanism and associated unittests.

### DIFF
--- a/dialect.go
+++ b/dialect.go
@@ -54,6 +54,10 @@ type Dialect interface {
 	// schema - The schema that <table> lives in
 	// table - The table name
 	QuotedTableForQuery(schema string, table string) string
+
+	// SupportsUpsert returns true if gorp includes dialect-specific support
+	// for the upsert (insert or update) statement.
+	SupportsUpsert() bool
 }
 
 // IntegerAutoIncrInserter is implemented by dialects that can perform
@@ -169,6 +173,10 @@ func (d SqliteDialect) QuotedTableForQuery(schema string, table string) string {
 	return d.QuoteField(table)
 }
 
+func (d SqliteDialect) SupportsUpsert() bool {
+	return false
+}
+
 ///////////////////////////////////////////////////////
 // PostgreSQL //
 ////////////////
@@ -276,6 +284,10 @@ func (d PostgresDialect) QuotedTableForQuery(schema string, table string) string
 	}
 
 	return schema + "." + d.QuoteField(table)
+}
+
+func (d PostgresDialect) SupportsUpsert() bool {
+	return false
 }
 
 ///////////////////////////////////////////////////////
@@ -400,6 +412,10 @@ func (d MySQLDialect) QuotedTableForQuery(schema string, table string) string {
 	return schema + "." + d.QuoteField(table)
 }
 
+func (d MySQLDialect) SupportsUpsert() bool {
+	return true
+}
+
 ///////////////////////////////////////////////////////
 // Sql Server //
 ////////////////
@@ -503,6 +519,10 @@ func (d SqlServerDialect) QuotedTableForQuery(schema string, table string) strin
 		return table
 	}
 	return schema + "." + table
+}
+
+func (d SqlServerDialect) SupportsUpsert() bool {
+	return false
 }
 
 func (d SqlServerDialect) QuerySuffix() string { return ";" }
@@ -614,4 +634,8 @@ func (d OracleDialect) QuotedTableForQuery(schema string, table string) string {
 	}
 
 	return schema + "." + d.QuoteField(table)
+}
+
+func (d OracleDialect) SupportsUpsert() bool {
+	return false
 }

--- a/gorp.go
+++ b/gorp.go
@@ -174,6 +174,7 @@ type TableMap struct {
 	version        *ColumnMap
 	insertPlan     bindPlan
 	updatePlan     bindPlan
+	upsertPlan     bindPlan
 	deletePlan     bindPlan
 	getPlan        bindPlan
 	dbmap          *DbMap
@@ -185,6 +186,7 @@ type TableMap struct {
 func (t *TableMap) ResetSql() {
 	t.insertPlan = bindPlan{}
 	t.updatePlan = bindPlan{}
+	t.upsertPlan = bindPlan{}
 	t.deletePlan = bindPlan{}
 	t.getPlan = bindPlan{}
 }
@@ -452,6 +454,81 @@ func (t *TableMap) bindUpdate(elem reflect.Value) (bindInstance, error) {
 	return plan.createBindInstance(elem, t.dbmap.TypeConverter)
 }
 
+// TODO(spencer.kimball@gmail.com): this is very MySQL-specific. I'm
+// not really sure yet what the best way to generalize this is using
+// the Dialect construct. I think the right next step is to start
+// supporting another database type and see what makes sense with that
+// specific case in mind.
+func (t *TableMap) bindUpsert(elem reflect.Value) (bindInstance, error) {
+	if !t.dbmap.Dialect.SupportsUpsert() {
+		return bindInstance{}, fmt.Errorf("SQL dialect doesn't have gorp support for upsert; consider adding it!")
+	}
+	plan := t.upsertPlan
+	if plan.query == "" {
+		plan.autoIncrIdx = -1
+
+		s := bytes.Buffer{}
+		s2 := bytes.Buffer{}
+		s.WriteString(fmt.Sprintf("insert into %s (", t.dbmap.Dialect.QuotedTableForQuery(t.SchemaName, t.TableName)))
+
+		x := 0
+		first := true
+		for y := range t.Columns {
+			col := t.Columns[y]
+			// TODO(spencer.kimball@gmail.com): there are ways to handle
+			// auto increment columns with upsert in MySQL, and no doubt other
+			// databases as well.
+			if col.isAutoIncr {
+				return bindInstance{}, fmt.Errorf("gorp: cannot upsert to tables with autoincrement field %q", col.fieldName)
+			}
+			if !col.Transient {
+				if !first {
+					s.WriteString(",")
+					s2.WriteString(",")
+				}
+				s.WriteString(t.dbmap.Dialect.QuoteField(col.ColumnName))
+
+				s2.WriteString(t.dbmap.Dialect.BindVar(x))
+				if col == t.version {
+					plan.versField = col.fieldName
+					plan.argFields = append(plan.argFields, versFieldConst)
+				} else {
+					plan.argFields = append(plan.argFields, col.fieldName)
+				}
+
+				x++
+				first = false
+			}
+		}
+		s.WriteString(") values (")
+		s.WriteString(s2.String())
+		s.WriteString(")")
+
+		s.WriteString(" on duplicate key update")
+		first = true
+		for y := range t.Columns {
+			col := t.Columns[y]
+			// Skip primary key and transient columns.
+			if col.isPK || col.Transient {
+				continue
+			}
+			if !first {
+				s.WriteString(",")
+			}
+			qf := t.dbmap.Dialect.QuoteField(col.ColumnName)
+			s.WriteString(fmt.Sprintf(" %s=values(%s)", qf, qf))
+			first = false
+		}
+
+		s.WriteString(t.dbmap.Dialect.QuerySuffix())
+
+		plan.query = s.String()
+		t.upsertPlan = plan
+	}
+
+	return plan.createBindInstance(elem, t.dbmap.TypeConverter)
+}
+
 func (t *TableMap) bindDelete(elem reflect.Value) (bindInstance, error) {
 	plan := t.deletePlan
 	if plan.query == "" {
@@ -605,7 +682,7 @@ func (c *ColumnMap) SetMaxSize(size int) *ColumnMap {
 }
 
 // Transaction represents a database transaction.
-// Insert/Update/Delete/Get/Exec operations will be run in the context
+// Insert/Update/Upsert/Delete/Get/Exec operations will be run in the context
 // of that transaction.  Transactions should be terminated with
 // a call to Commit() or Rollback()
 type Transaction struct {
@@ -624,6 +701,7 @@ type SqlExecutor interface {
 	Get(i interface{}, keys ...interface{}) (interface{}, error)
 	Insert(list ...interface{}) error
 	Update(list ...interface{}) (int64, error)
+	Upsert(list ...interface{}) error
 	Delete(list ...interface{}) (int64, error)
 	Exec(query string, args ...interface{}) (sql.Result, error)
 	Select(i interface{}, query string,
@@ -969,6 +1047,23 @@ func (m *DbMap) Update(list ...interface{}) (int64, error) {
 	return update(m, m, list...)
 }
 
+// Upsert runs a SQL statement specific to each dialog which either
+// inserts or updates each element in the list according to whether or
+// not it is already in the database (update) or is not yet in the
+// database (insert). List items must be pointers.
+//
+// Only TableMaps without auto-incrementing primary keys are
+// allowed. Any interface whose TableMap has an auto-increment primary
+// key will result in an error.
+//
+// The hook functions PreUpsert() and/or PostUpsert() will be executed
+// before/after the upsert if the interface defines them.
+//
+// Panics if any interface in the list has not been registered with AddTable
+func (m *DbMap) Upsert(list ...interface{}) error {
+	return upsert(m, m, list...)
+}
+
 // Delete runs a SQL DELETE statement for each element in list.  List
 // items must be pointers.
 //
@@ -1173,6 +1268,11 @@ func (t *Transaction) Insert(list ...interface{}) error {
 // Update had the same behavior as DbMap.Update(), but runs in a transaction.
 func (t *Transaction) Update(list ...interface{}) (int64, error) {
 	return update(t.dbmap, t, list...)
+}
+
+// Upsert has the same behavior as DbMap.Upsert(), but runs in a transaction.
+func (t *Transaction) Upsert(list ...interface{}) error {
+	return upsert(t.dbmap, t, list...)
 }
 
 // Delete has the same behavior as DbMap.Delete(), but runs in a transaction.
@@ -1959,6 +2059,41 @@ func insert(m *DbMap, exec SqlExecutor, list ...interface{}) error {
 	return nil
 }
 
+func upsert(m *DbMap, exec SqlExecutor, list ...interface{}) error {
+	for _, ptr := range list {
+		table, elem, err := m.tableForPointer(ptr, false)
+		if err != nil {
+			return err
+		}
+
+		eval := elem.Addr().Interface()
+		if v, ok := eval.(HasPreUpsert); ok {
+			err := v.PreUpsert(exec)
+			if err != nil {
+				return err
+			}
+		}
+
+		bi, err := table.bindUpsert(elem)
+		if err != nil {
+			return err
+		}
+		fmt.Println(bi.query)
+		_, err = exec.Exec(bi.query, bi.args...)
+		if err != nil {
+			return err
+		}
+
+		if v, ok := eval.(HasPostUpsert); ok {
+			err := v.PostUpsert(exec)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 func lockError(m *DbMap, exec SqlExecutor, tableName string,
 	existingVer int64, elem reflect.Value,
 	keys ...interface{}) (int64, error) {
@@ -1980,19 +2115,24 @@ type HasPostGet interface {
 	PostGet(SqlExecutor) error
 }
 
-// PostUpdate() will be executed after the DELETE statement
+// PostUpdate() will be executed after the DELETE statement.
 type HasPostDelete interface {
 	PostDelete(SqlExecutor) error
 }
 
-// PostUpdate() will be executed after the UPDATE statement
+// PostUpdate() will be executed after the UPDATE statement.
 type HasPostUpdate interface {
 	PostUpdate(SqlExecutor) error
 }
 
-// PostInsert() will be executed after the INSERT statement
+// PostInsert() will be executed after the INSERT statement.
 type HasPostInsert interface {
 	PostInsert(SqlExecutor) error
+}
+
+// PostUpsert() will be executed after an upsert statement.
+type HasPostUpsert interface {
+	PostUpsert(SqlExecutor) error
 }
 
 // PreDelete() will be executed before the DELETE statement.
@@ -2008,4 +2148,9 @@ type HasPreUpdate interface {
 // PreInsert() will be executed before INSERT statement.
 type HasPreInsert interface {
 	PreInsert(SqlExecutor) error
+}
+
+// PreUpsert() will be executed before an upsert statement.
+type HasPreUpsert interface {
+	PreUpsert(SqlExecutor) error
 }

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -6,16 +6,17 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	_ "github.com/go-sql-driver/mysql"
-	_ "github.com/lib/pq"
-	_ "github.com/mattn/go-sqlite3"
-	_ "github.com/ziutek/mymysql/godrv"
 	"log"
 	"os"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	_ "github.com/lib/pq"
+	_ "github.com/mattn/go-sqlite3"
+	_ "github.com/ziutek/mymysql/godrv"
 )
 
 // verify interface compliance
@@ -206,6 +207,16 @@ func (p *Person) PreUpdate(s SqlExecutor) error {
 
 func (p *Person) PostUpdate(s SqlExecutor) error {
 	p.LName = "postupdate"
+	return nil
+}
+
+func (p *Person) PreUpsert(s SqlExecutor) error {
+	p.FName = "preupsert"
+	return nil
+}
+
+func (p *Person) PostUpsert(s SqlExecutor) error {
+	p.LName = "postupsert"
 	return nil
 }
 
@@ -803,6 +814,15 @@ func TestHooks(t *testing.T) {
 		t.Errorf("p1.PostUpdate() didn't run: %v", p1)
 	}
 
+	if dbmap.Dialect.SupportsUpsert() {
+		_upsert(dbmap, p1)
+		if p1.FName != "preupsert" {
+			t.Errorf("p1.PreUpsert() didn't run: %v", p1)
+		} else if p1.LName != "postupsert" {
+			t.Errorf("p1.PostUpsert() didn't run: %v", p1)
+		}
+	}
+
 	var persons []*Person
 	bindVar := dbmap.Dialect.BindVar(0)
 	_rawselect(dbmap, &persons, "select * from person_test where id = "+bindVar, p1.Id)
@@ -969,6 +989,46 @@ func TestCrud(t *testing.T) {
 	obj = _get(dbmap, Invoice{}, inv.Id)
 	if obj != nil {
 		t.Errorf("Found invoice with id: %d after Delete()", inv.Id)
+	}
+}
+
+func TestUpsert(t *testing.T) {
+	dbmap := initDbMap()
+	defer dropAndClose(dbmap)
+	if !dbmap.Dialect.SupportsUpsert() {
+		return
+	}
+
+	// First, try an upsert with an auto-increment table.
+	inv := &Invoice{0, 100, 200, "first order", 0, true}
+	if err := dbmap.Upsert(inv); err == nil {
+		t.Error("expected failure trying to upsert a row to an auto-increment table")
+	}
+
+	oinv := &OverriddenInvoice{
+		Invoice: *inv,
+		Id:      "1",
+	}
+
+	// Upsert for insert.
+	_upsert(dbmap, oinv)
+
+	// SELECT row to verify insert.
+	obj := _get(dbmap, OverriddenInvoice{}, oinv.Id)
+	oinv2 := obj.(*OverriddenInvoice)
+	if !reflect.DeepEqual(oinv, oinv2) {
+		t.Errorf("%v != %v", oinv, oinv2)
+	}
+
+	// Upsert again with modifications.
+	oinv.Memo = "second order"
+	oinv.Created = 999
+	oinv.Updated = 11111
+	_upsert(dbmap, oinv)
+	obj = _get(dbmap, OverriddenInvoice{}, oinv.Id)
+	oinv2 = obj.(*OverriddenInvoice)
+	if !reflect.DeepEqual(oinv, oinv2) {
+		t.Errorf("%v != %v", oinv, oinv2)
 	}
 }
 
@@ -1719,6 +1779,13 @@ func _update(dbmap *DbMap, list ...interface{}) int64 {
 		panic(err)
 	}
 	return count
+}
+
+func _upsert(dbmap *DbMap, list ...interface{}) {
+	err := dbmap.Upsert(list...)
+	if err != nil {
+		panic(err)
+	}
 }
 
 func _del(dbmap *DbMap, list ...interface{}) int64 {


### PR DESCRIPTION
Upsert is a portmanteau for "update" and "insert". It allows a single
statement to either insert if the primary key is not presetn or update
if it is present.

The current implementation is MySQL specific and will return an error
for any other dialect. Support for this feature varies widely amongst
database vendors as it's not part of the SQL ansi standard. For MySQL,
we use the "ON DUPLICATE KEY UPDATE ..." suffix to insert statements.