### PR TITLE
return non-fatal NoFieldInTypeError when selecting too many columns (with tests)

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,26 @@
+package gorp
+
+import (
+	"fmt"
+)
+
+// A non-fatal error, when a select query returns columns that do not exist
+// as fields in the struct it is being mapped to
+type NoFieldInTypeError struct {
+	TypeName        string
+	MissingColNames []string
+}
+
+func (err *NoFieldInTypeError) Error() string {
+	return fmt.Sprintf("gorp: No fields %+v in type %s", err.MissingColNames, err.TypeName)
+}
+
+// returns true if the error is non-fatal (ie, we shouldn't immediately return)
+func NonFatalError(err error) bool {
+	switch err.(type) {
+	case *NoFieldInTypeError:
+		return true
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
We are using gorp in production with a medium-sized team (10 developers + 3 contractors). Our deploys go like this:
1. Migrate the db
2. Push the new code

The issue is that, in between the first and second step, we potentially have more database columns than fields in a struct. If someone wrote a query with `select *`, that query will now error, and the API will go down. 

This isn't a problem if no one ever does `select *`, but we are a startup and work long hours, sometimes pushing code when we're tired. Not all lines of code will be reviewed, not everything will be thought out all the time, and slip-ups are all but guaranteed. And as we rapidly add more people to the team, this behavior becomes very dangerous for the stability of our production system.

I understand that some people might want the current behavior, and the error should definitely not be silently swallowed. In the case of too many columns, the code in this pull request will return a specific type of error, `NoFieldInTypeError`, but otherwise proceed normally. The caller can check if the error is a `NoFieldInTypeError`, or just use `gorp.NonFatalError(err)` to see if the program can continue.
