### PR TITLE
Fixes #195

### DIFF
--- a/gorp.go
+++ b/gorp.go
@@ -813,7 +813,7 @@ func (m *DbMap) createTables(ifNotExists bool) error {
 			} else {
 				s.WriteString(schemaCreate)
 			}
-			fmt.Sprintf(" %s;", table.SchemaName)
+			s.WriteString(fmt.Sprintf(" %s;", table.SchemaName))
 		}
 
 		tableCreate := "create table"


### PR DESCRIPTION
It looks like the table name and semicolon weren't being written to the buffer during the createTables method call.
