### PR TITLE
Interface to assign ID with a query after insert (like OracleDialect)

### DIFF
--- a/gorp.go
+++ b/gorp.go
@@ -554,6 +554,9 @@ type ColumnMap struct {
 	// Not used elsewhere
 	Unique bool
 
+	// Query used for getting generated id after insert
+	GeneratedIdQuery string
+
 	// Passed to Dialect.ToSqlType() to assist in informing the
 	// correct column type to map to in CreateTables()
 	// Not used elsewhere
@@ -2007,6 +2010,15 @@ func insert(m *DbMap, exec SqlExecutor, list ...interface{}) error {
 				}
 			case TargetedAutoIncrInserter:
 				err := inserter.InsertAutoIncrToTarget(exec, bi.query, f.Addr().Interface(), bi.args...)
+				if err != nil {
+					return err
+				}
+			case TargetQueryInserter:
+				var idQuery = table.ColMap(bi.autoIncrFieldName).GeneratedIdQuery
+				if idQuery == "" {
+					return fmt.Errorf("gorp: Cannot set %s value if its ColumnMap.GeneratedIdQuery is empty", bi.autoIncrFieldName)
+				}
+				err := inserter.InsertQueryToTarget(exec, bi.query, idQuery, f.Addr().Interface(), bi.args...)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
Hi, I noticed that in the former version of Oracle Dialect the automatic fetch of a generate id was missing.
I created a new Interface for the purpose: `TargetQueryInserter`

Here is an Example of usage:

	var obj struct {
		Id int64
	}
	var t = dbMap.AddTable(obj)
	t.SetKeys(true, "Id")
	t.ColMap("Id").GeneratedIdQuery = "SELECT sequence.currval FROM DUAL"
