### PR TITLE
Update gorp.go

### DIFF
--- a/gorp.go
+++ b/gorp.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 	"log"
+	"os"
 )
 
 // Oracle String (empty string is null)
@@ -777,7 +778,9 @@ func (m *DbMap) readStructColumns(t reflect.Type) (cols []*ColumnMap, version *C
 				cols = append(cols, cm)
 			}
 			if cm.fieldName == "Version" {
+				log.SetOutput(os.Stderr)
 				log.Println("Warning: Automatic mapping of Version struct members to version columns will be deprecated in next version (V2) See: https://github.com/go-gorp/gorp/pull/214") 
+				log.SetOutput(os.Stdout) //Not sure if this is necessary
 				version = cm
 			}
 		}

--- a/gorp.go
+++ b/gorp.go
@@ -21,6 +21,7 @@ import (
 	"regexp"
 	"strings"
 	"time"
+	"log"
 )
 
 // Oracle String (empty string is null)
@@ -776,6 +777,7 @@ func (m *DbMap) readStructColumns(t reflect.Type) (cols []*ColumnMap, version *C
 				cols = append(cols, cm)
 			}
 			if cm.fieldName == "Version" {
+				log.Println("Warning: Automatic mapping of Version struct members to version columns will be deprecated in next version (V2) See: https://github.com/go-gorp/gorp/pull/214") 
 				version = cm
 			}
 		}

--- a/gorp.go
+++ b/gorp.go
@@ -778,9 +778,7 @@ func (m *DbMap) readStructColumns(t reflect.Type) (cols []*ColumnMap, version *C
 				cols = append(cols, cm)
 			}
 			if cm.fieldName == "Version" {
-				log.SetOutput(os.Stderr)
-				log.Println("Warning: Automatic mapping of Version struct members to version columns will be deprecated in next version (V2) See: https://github.com/go-gorp/gorp/pull/214") 
-				log.SetOutput(os.Stdout) //Not sure if this is necessary
+				log.New(os.Stderr, "", log.LstdFlags).Println("Warning: Automatic mapping of Version struct members to version columns (see optimistic locking) will be deprecated in next version (V2) See: https://github.com/go-gorp/gorp/pull/214")
 				version = cm
 			}
 		}


### PR DESCRIPTION
Added warning telling users that automatic mapping of Version struct members to version column in database (optimistic locking) will be removed in V2.

See PR: https://github.com/go-gorp/gorp/pull/214