### PR TITLE
Fix expand query on NullTime or other structs.

### DIFF
--- a/gorp.go
+++ b/gorp.go
@@ -1691,20 +1691,32 @@ func exec(e SqlExecutor, query string, args ...interface{}) (sql.Result, error) 
 // parameters by extracting data from the map / struct.
 // If not, returns the input values unchanged.
 func maybeExpandNamedQuery(m *DbMap, query string, args []interface{}) (string, []interface{}) {
-	arg := reflect.ValueOf(args[0])
-	for arg.Kind() == reflect.Ptr {
-		arg = arg.Elem()
+	var (
+		arg    = args[0]
+		argval = reflect.ValueOf(arg)
+	)
+	if argval.Kind() == reflect.Ptr {
+		argval = argval.Elem()
 	}
-	switch {
-	case arg.Kind() == reflect.Map && arg.Type().Key().Kind() == reflect.String:
+
+	if argval.Kind() == reflect.Map && argval.Type().Key().Kind() == reflect.String {
 		return expandNamedQuery(m, query, func(key string) reflect.Value {
-			return arg.MapIndex(reflect.ValueOf(key))
+			return argval.MapIndex(reflect.ValueOf(key))
 		})
-		// #84 - ignore time.Time structs here - there may be a cleaner way to do this
-	case arg.Kind() == reflect.Struct && !(arg.Type().PkgPath() == "time" && arg.Type().Name() == "Time"):
-		return expandNamedQuery(m, query, arg.FieldByName)
 	}
-	return query, args
+	if argval.Kind() != reflect.Struct {
+		return query, args
+	}
+	if _, ok := arg.(time.Time); ok {
+		// time.Time is driver.Value
+		return query, args
+	}
+	if _, ok := arg.(driver.Valuer); ok {
+		// driver.Valuer will be converted to driver.Value.
+		return query, args
+	}
+
+	return expandNamedQuery(m, query, argval.FieldByName)
 }
 
 var keyRegexp = regexp.MustCompile(`:[[:word:]]+`)


### PR DESCRIPTION
Gorp decide expanding query if only one struct passed as argument,  but it is not good.
Here is example.

```go
type Table struct {
    Id      int
    Time gorp.NullTime
}

dbmap.AddTableWithName(Table{}, "TEST_TABLE").SetKeys(true, "Id")
dbmap.Insert(&Table{
    Time: gorp.NullTime {
        Valid: true,
        Time: time.Now(),
    },
})
```

I expect write the time to DB, but empty because placeholder arguments are deleted by `expandNamedQuery()`.
`maybeExpandNamedQuery()` passes query and placeholder arguments to expandNamedQuery() if length of args is 1 and args[0] is ```map[string]interface{}``` or ```struct```.

So, I changed to `maybeExpandNamedQuery()` dosen't pass this if args[0] is sql.Valuer.

thank you.