### PR TITLE
Set column size by struct tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,8 @@ type Post struct {
     // db tag lets you specify the column name if it differs from the struct field
     Id      int64  `db:"post_id"`
     Created int64
-    Title   string `db:",50"`       // Column size set to 50
-    Body    string `db:"text,1024"` // Set both column name and size
+    Title   string `db:",size:50"`               // Column size set to 50
+    Body    string `db:"article_body,size:1024"` // Set both column name and size
 }
 
 func newPost(title, body string) Post {

--- a/README.md
+++ b/README.md
@@ -143,10 +143,10 @@ func main() {
 
 type Post struct {
     // db tag lets you specify the column name if it differs from the struct field
-    Id      int64 `db:"post_id"`
+    Id      int64  `db:"post_id"`
     Created int64
-    Title   string
-    Body    string
+    Title   string `db:",50"`       // Column size set to 50
+    Body    string `db:"text,1024"` // Set both column name and size
 }
 
 func newPost(title, body string) Post {

--- a/gorp.go
+++ b/gorp.go
@@ -769,7 +769,7 @@ func (m *DbMap) readStructColumns(t reflect.Type) (cols []*ColumnMap) {
 			cArguments := strings.Split(f.Tag.Get("db"), ",")
 			columnName := cArguments[0]
 			var maxSize int
-			for i, argString := range cArguments[1:] {
+			for _, argString := range cArguments[1:] {
 				arg := strings.SplitN(argString, ":", 2)
 				switch arg[0] {
 				case "size":

--- a/gorp.go
+++ b/gorp.go
@@ -764,32 +764,18 @@ func (m *DbMap) readStructColumns(t reflect.Type) (cols []*ColumnMap) {
 				}
 			}
 		} else {
+			// Tag = Name { ','  Option }
+			// Option = OptionKey [ ':' OptionValue ]
+			cArguments := strings.Split(f.Tag.Get("db"), ",")
+			columnName := cArguments[0]
 			var maxSize int
-			var columnName string
-
-			// Split arguments using comma as separator.
-			// Boolean values should default to "true".
-			// The first argument key, if provided without an explicit value,
-			// and if not recognized as a named argument, is used as the field name,
-			// as long as there isn't a "name" argument.
-			for i, argString := range strings.Split(f.Tag.Get("db"), ",") {
+			for i, argString := range cArguments[1:] {
 				arg := strings.SplitN(argString, ":", 2)
-				argK := strings.TrimSpace(arg[0])
-				var argV string
-				if len(arg) > 1 {
-					argV = strings.TrimSpace(arg[1])
-				}
-				switch argK {
-				case "name":
-					columnName = argV
+				switch arg[0] {
 				case "size":
-					maxSize, _ = strconv.Atoi(argV)
+					maxSize, _ = strconv.Atoi(arg[1])
 				default:
-					if i == 0 && argV == "" {
-						columnName = argK
-					} else {
-						//log.Printf("Unrecognized argument key: %v\n", argK)
-					}
+					//log.Printf("Unrecognized argument: %v\n", arg)
 				}
 			}
 			if columnName == "" {

--- a/gorp.go
+++ b/gorp.go
@@ -772,8 +772,7 @@ func (m *DbMap) readStructColumns(t reflect.Type) (cols []*ColumnMap) {
 			// The first argument key, if provided without an explicit value,
 			// and if not recognized as a named argument, is used as the field name,
 			// as long as there isn't a "name" argument.
-			cArguments := strings.Split(f.Tag.Get("db"), ",")
-			for i, argString := range strings.Split(cArguments, ",") {
+			for i, argString := range strings.Split(f.Tag.Get("db"), ",") {
 				arg := strings.SplitN(argString, ":", 2)
 				argK := strings.TrimSpace(arg[0])
 				var argV string

--- a/gorp.go
+++ b/gorp.go
@@ -775,7 +775,7 @@ func (m *DbMap) readStructColumns(t reflect.Type) (cols []*ColumnMap) {
 				case "size":
 					maxSize, _ = strconv.Atoi(arg[1])
 				default:
-					//log.Printf("Unrecognized argument: %v\n", arg)
+					panic(fmt.Sprintf("Unrecognized tag argument for field %v: %v", f.Name, arg))
 				}
 			}
 			if columnName == "" {

--- a/gorp.go
+++ b/gorp.go
@@ -764,13 +764,34 @@ func (m *DbMap) readStructColumns(t reflect.Type) (cols []*ColumnMap) {
 				}
 			}
 		} else {
-			cArguments := strings.SplitN(f.Tag.Get("db"), ",", 2)
-			columnName := cArguments[0]
 			var maxSize int
-			// If there is a second argument in the tag,
-			// use it as column max size.
-			if len(cArguments) > 1 {
-				maxSize, _ = strconv.Atoi(cArguments[1])
+			var columnName string
+
+			// Split arguments using comma as separator.
+			// Boolean values should default to "true".
+			// The first argument key, if provided without an explicit value,
+			// and if not recognized as a named argument, is used as the field name,
+			// as long as there isn't a "name" argument.
+			cArguments := strings.Split(f.Tag.Get("db"), ",")
+			for i, argString := range strings.Split(cArguments, ",") {
+				arg := strings.SplitN(argString, ":", 2)
+				argK := strings.TrimSpace(arg[0])
+				var argV string
+				if len(arg) > 1 {
+					argV = strings.TrimSpace(arg[1])
+				}
+				switch argK {
+				case "name":
+					columnName = argV
+				case "size":
+					maxSize, _ = strconv.Atoi(argV)
+				default:
+					if i == 0 && argV == "" {
+						columnName = argK
+					} else {
+						//log.Printf("Unrecognized argument key: %v\n", argK)
+					}
+				}
 			}
 			if columnName == "" {
 				columnName = f.Name


### PR DESCRIPTION
Addressing #178 by adding a second optional argument to the `db` tag which maps to column `MaxSize` property.