### PR TITLE
Add a -trace flag to allow us to shut off db trace logs

### DIFF
--- a/test_all.sh
+++ b/test_all.sh
@@ -5,18 +5,22 @@
 
 set -e 
 
+echo "Testing against mysql"
 export GORP_TEST_DSN=gorptest/gorptest/gorptest
 export GORP_TEST_DIALECT=mysql
-go test $GOBUILDFLAG .
+go test $GOBUILDFLAG $@ .
 
+echo "Testing against gomysql"
 export GORP_TEST_DSN=gorptest:gorptest@/gorptest
 export GORP_TEST_DIALECT=gomysql
-go test $GOBUILDFLAG .
+go test $GOBUILDFLAG $@ .
 
+echo "Testing against postgres"
 export GORP_TEST_DSN="user=gorptest password=gorptest dbname=gorptest sslmode=disable"
 export GORP_TEST_DIALECT=postgres
-go test $GOBUILDFLAG .
+go test $GOBUILDFLAG $@ .
 
+echo "Testing against sqlite"
 export GORP_TEST_DSN=/tmp/gorptest.bin
 export GORP_TEST_DIALECT=sqlite
-go test $GOBUILDFLAG .
+go test $GOBUILDFLAG $@ .


### PR DESCRIPTION
I was getting really tired of my failing test output getting lost in the DB logs, and running find/replace each time I want to silence logs seems like a bad idea.  This PR adds a `-trace` flag which allows us to shut off DB logs using `-trace=false` or `-trace false`.  It also updates `test_all.sh` to pass any command line parameters along to the `go test` commands, so that we can run `./test_all.sh -trace=false` to silence logs, or `./test_all.sh -test.run SomeTestName` to explicitly run a single test.