### PR TITLE
address #266: make match function aware of multiple tags

### DIFF
--- a/gorp.go
+++ b/gorp.go
@@ -1851,7 +1851,8 @@ func columnToFieldIndex(m *DbMap, t reflect.Type, cols []string) ([][]int, error
 		colName := strings.ToLower(cols[x])
 		field, found := t.FieldByNameFunc(func(fieldName string) bool {
 			field, _ := t.FieldByName(fieldName)
-			fieldName = field.Tag.Get("db")
+			cArguments := strings.Split(field.Tag.Get("db"), ",")
+			fieldName = cArguments[0]
 
 			if fieldName == "-" {
 				return false


### PR DESCRIPTION
Since the introduction of `size` tag, we didn't update the select function.

I've just repeated the logic we put in the "create table" function.

A more sustainable solution could be using a `type Field reflect.StructType` custom type to put the "find-the-name" and "find-the-size" logic in one place.