### PR TITLE
Don't ignore the return errors from Insert in documentation examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,11 +402,13 @@ type InvoicePersonView struct {
 
 // Create some rows
 p1 := &Person{0, 0, 0, "bob", "smith"}
-dbmap.Insert(p1)
+err = dbmap.Insert(p1)
+checkErr(err, "Insert failed")
 
 // notice how we can wire up p1.Id to the invoice easily
 inv1 := &Invoice{0, 0, 0, "xmas order", p1.Id}
-dbmap.Insert(inv1)
+err = dbmap.Insert(inv1)
+checkErr(err, "Insert failed")
 
 // Run your query
 query := "select i.Id InvoiceId, p.Id PersonId, i.Memo, p.FName " +
@@ -469,9 +471,12 @@ func InsertInv(dbmap *DbMap, inv *Invoice, per *Person) error {
         return err
     }
 
-    trans.Insert(per)
+    err = trans.Insert(per)
+    checkErr(err, "Insert failed")
+
     inv.PersonId = per.Id
-    trans.Insert(inv)
+    err = trans.Insert(inv)
+    checkErr(err, "Insert failed")
 
     // if the commit is successful, a nil error is returned
     return trans.Commit()
@@ -553,12 +558,14 @@ type Person struct {
 }
 
 p1 := &Person{0, 0, 0, "Bob", "Smith", 0}
-dbmap.Insert(p1)  // Version is now 1
+err = dbmap.Insert(p1)  // Version is now 1
+checkErr(err, "Insert failed")
 
 obj, err := dbmap.Get(Person{}, p1.Id)
 p2 := obj.(*Person)
 p2.LName = "Edwards"
-dbmap.Update(p2)  // Version is now 2
+_,err = dbmap.Update(p2)  // Version is now 2
+checkErr(err, "Update failed")
 
 p1.LName = "Howard"
 


### PR DESCRIPTION
I wrote a transaction based on the documentation, ran my program, and was confused that it was silently failing. It turned out that I had forgotten to pass a pointer to `Insert`, and had also forgotten to check for errors after each insert (thinking all error checking was done on commit).

This PR shows that `Insert` returns an error in examples in the documentation, so that when someone makes my mistake again, they might have a few more clues about what's going wrong.
