### PR TITLE
Fix multiple columns in CreateIndex()

### DIFF
--- a/db.go
+++ b/db.go
@@ -64,8 +64,7 @@ func (m *DbMap) CreateIndex() error {
 				s.WriteString(fmt.Sprintf(" %s %s", m.Dialect.CreateIndexSuffix(), index.IndexType))
 			}
 			s.WriteString(" (")
-			x := 0
-			for _, col := range index.columns {
+			for x, col := range index.columns {
 				if x > 0 {
 					s.WriteString(", ")
 				}


### PR DESCRIPTION
Given we add an index like this:

    AddIndex("app_name_type_UNIQUE", "Btree", []string{"app_name", "type"}).SetUnique(true)

We were seeing the generated SQL like this:

    create unique index app_name_type_UNIQUE on app_tbl ("app_name""type"); [] (14.774µs)