### PR TITLE
Fix package level docs

### DIFF
--- a/column.go
+++ b/column.go
@@ -8,7 +8,7 @@
 //
 // Source code and project home:
 // https://github.com/go-gorp/gorp
-//
+
 package gorp
 
 import "reflect"

--- a/db.go
+++ b/db.go
@@ -8,7 +8,7 @@
 //
 // Source code and project home:
 // https://github.com/go-gorp/gorp
-//
+
 package gorp
 
 import (

--- a/dialect.go
+++ b/dialect.go
@@ -8,7 +8,7 @@
 //
 // Source code and project home:
 // https://github.com/go-gorp/gorp
-//
+
 package gorp
 
 import "reflect"

--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -8,7 +8,7 @@
 //
 // Source code and project home:
 // https://github.com/go-gorp/gorp
-//
+
 package gorp
 
 import (

--- a/dialect_oracle.go
+++ b/dialect_oracle.go
@@ -8,7 +8,7 @@
 //
 // Source code and project home:
 // https://github.com/go-gorp/gorp
-//
+
 package gorp
 
 import (

--- a/dialect_postgres.go
+++ b/dialect_postgres.go
@@ -8,7 +8,7 @@
 //
 // Source code and project home:
 // https://github.com/go-gorp/gorp
-//
+
 package gorp
 
 import (

--- a/dialect_sqlite.go
+++ b/dialect_sqlite.go
@@ -8,7 +8,7 @@
 //
 // Source code and project home:
 // https://github.com/go-gorp/gorp
-//
+
 package gorp
 
 import (

--- a/dialect_sqlserver.go
+++ b/dialect_sqlserver.go
@@ -8,7 +8,7 @@
 //
 // Source code and project home:
 // https://github.com/go-gorp/gorp
-//
+
 package gorp
 
 import (

--- a/errors.go
+++ b/errors.go
@@ -8,7 +8,7 @@
 //
 // Source code and project home:
 // https://github.com/go-gorp/gorp
-//
+
 package gorp
 
 import (

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -8,7 +8,7 @@
 //
 // Source code and project home:
 // https://github.com/go-gorp/gorp
-//
+
 package gorp
 
 import (

--- a/hooks.go
+++ b/hooks.go
@@ -8,7 +8,7 @@
 //
 // Source code and project home:
 // https://github.com/go-gorp/gorp
-//
+
 package gorp
 
 //++ TODO v2-phase3: HasPostGet => PostGetter, HasPostDelete => PostDeleter, etc.

--- a/index.go
+++ b/index.go
@@ -8,7 +8,7 @@
 //
 // Source code and project home:
 // https://github.com/go-gorp/gorp
-//
+
 package gorp
 
 // IndexMap represents a mapping between a Go struct field and a single

--- a/lockerror.go
+++ b/lockerror.go
@@ -8,7 +8,7 @@
 //
 // Source code and project home:
 // https://github.com/go-gorp/gorp
-//
+
 package gorp
 
 import (

--- a/logging.go
+++ b/logging.go
@@ -8,7 +8,7 @@
 //
 // Source code and project home:
 // https://github.com/go-gorp/gorp
-//
+
 package gorp
 
 import "fmt"

--- a/nulltypes.go
+++ b/nulltypes.go
@@ -8,7 +8,7 @@
 //
 // Source code and project home:
 // https://github.com/go-gorp/gorp
-//
+
 package gorp
 
 import (

--- a/select.go
+++ b/select.go
@@ -8,7 +8,7 @@
 //
 // Source code and project home:
 // https://github.com/go-gorp/gorp
-//
+
 package gorp
 
 import (

--- a/table.go
+++ b/table.go
@@ -8,7 +8,7 @@
 //
 // Source code and project home:
 // https://github.com/go-gorp/gorp
-//
+
 package gorp
 
 import (

--- a/table_bindings.go
+++ b/table_bindings.go
@@ -8,7 +8,7 @@
 //
 // Source code and project home:
 // https://github.com/go-gorp/gorp
-//
+
 package gorp
 
 import (

--- a/transaction.go
+++ b/transaction.go
@@ -8,7 +8,7 @@
 //
 // Source code and project home:
 // https://github.com/go-gorp/gorp
-//
+
 package gorp
 
 import (


### PR DESCRIPTION
By adding a space before package, it removes the duplicate package level docs.

(note, I left it in gorp.go)

thanks,