### PR TITLE
Remove go-1.2 from the list of test targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: go
 go:
-- 1.2
 - 1.3
 - 1.4
 - tip


### PR DESCRIPTION
Currently it's causing all of the tests to fail and giving us a "builds failing" badge on the front page, which doesn't look so great.

It's failing because mattn/sqlite3 doesn't support it anymore. I'm not
sure gorp should either, go-1.2 is really quite old now.