### PR TITLE
Default value should be set in schema

### DIFF
--- a/table.go
+++ b/table.go
@@ -214,6 +214,9 @@ func (t *TableMap) SqlForCreate(ifNotExists bool) string {
 			if col.isAutoIncr {
 				s.WriteString(fmt.Sprintf(" %s", dialect.AutoIncrStr()))
 			}
+			if col.DefaultValue != "" {
+				s.WriteString(fmt.Sprintf(" %s", col.DefaultValue))
+			}
 
 			x++
 		}


### PR DESCRIPTION
The default value in field tag, e.g., "db:"field,size:1,default:10", should be reflected in db schema too, besides setting it during insertion.
So the db schema will becomes "... DEFAULT '10'".
