### PR TITLE
move logs down to the core

### DIFF
--- a/db.go
+++ b/db.go
@@ -488,10 +488,6 @@ func (m *DbMap) Select(i interface{}, query string, args ...interface{}) ([]inte
 // Exec runs an arbitrary SQL statement.  args represent the bind parameters.
 // This is equivalent to running:  Exec() using database/sql
 func (m *DbMap) Exec(query string, args ...interface{}) (sql.Result, error) {
-	if m.logger != nil {
-		now := time.Now()
-		defer m.trace(now, query, args...)
-	}
 	return exec(m, query, args...)
 }
 

--- a/gorp.go
+++ b/gorp.go
@@ -156,6 +156,11 @@ func exec(e SqlExecutor, query string, args ...interface{}) (sql.Result, error) 
 		dbMap = m.dbmap
 	}
 
+	if dbMap.logger != nil {
+		now := time.Now()
+		defer dbMap.trace(now, query, args...)
+	}
+
 	if len(args) == 1 {
 		query, args = maybeExpandNamedQuery(dbMap, query, args)
 	}

--- a/transaction.go
+++ b/transaction.go
@@ -58,10 +58,6 @@ func (t *Transaction) Select(i interface{}, query string, args ...interface{}) (
 
 // Exec has the same behavior as DbMap.Exec(), but runs in a transaction.
 func (t *Transaction) Exec(query string, args ...interface{}) (sql.Result, error) {
-	if t.dbmap.logger != nil {
-		now := time.Now()
-		defer t.dbmap.trace(now, query, args...)
-	}
 	return exec(t, query, args...)
 }
 


### PR DESCRIPTION
this one moves the `Exec` log statements a bit deeper into the gorp core
