### PR TITLE
Fully export SqlExecutor

### DIFF
--- a/db.go
+++ b/db.go
@@ -599,7 +599,7 @@ func (m *DbMap) tableForPointer(ptr interface{}, checkPK bool) (*TableMap, refle
 	return t, elem, nil
 }
 
-func (m *DbMap) queryRow(query string, args ...interface{}) *sql.Row {
+func (m *DbMap) QueryRow(query string, args ...interface{}) *sql.Row {
 	if m.logger != nil {
 		now := time.Now()
 		defer m.trace(now, query, args...)
@@ -607,7 +607,7 @@ func (m *DbMap) queryRow(query string, args ...interface{}) *sql.Row {
 	return m.Db.QueryRow(query, args...)
 }
 
-func (m *DbMap) query(query string, args ...interface{}) (*sql.Rows, error) {
+func (m *DbMap) Query(query string, args ...interface{}) (*sql.Rows, error) {
 	if m.logger != nil {
 		now := time.Now()
 		defer m.trace(now, query, args...)

--- a/dialect_postgres.go
+++ b/dialect_postgres.go
@@ -104,7 +104,7 @@ func (d PostgresDialect) BindVar(i int) string {
 }
 
 func (d PostgresDialect) InsertAutoIncrToTarget(exec SqlExecutor, insertSql string, target interface{}, params ...interface{}) error {
-	rows, err := exec.query(insertSql, params...)
+	rows, err := exec.Query(insertSql, params...)
 	if err != nil {
 		return err
 	}

--- a/gorp.go
+++ b/gorp.go
@@ -110,8 +110,8 @@ type SqlExecutor interface {
 	SelectStr(query string, args ...interface{}) (string, error)
 	SelectNullStr(query string, args ...interface{}) (sql.NullString, error)
 	SelectOne(holder interface{}, query string, args ...interface{}) error
-	query(query string, args ...interface{}) (*sql.Rows, error)
-	queryRow(query string, args ...interface{}) *sql.Row
+	Query(query string, args ...interface{}) (*sql.Rows, error)
+	QueryRow(query string, args ...interface{}) *sql.Row
 }
 
 // Compile-time check that DbMap and Transaction implement the SqlExecutor
@@ -361,7 +361,7 @@ func get(m *DbMap, exec SqlExecutor, i interface{},
 		dest[x] = target
 	}
 
-	row := exec.queryRow(plan.query, keys...)
+	row := exec.QueryRow(plan.query, keys...)
 	err = row.Scan(dest...)
 	if err != nil {
 		if err == sql.ErrNoRows {

--- a/select.go
+++ b/select.go
@@ -162,7 +162,7 @@ func selectVal(e SqlExecutor, holder interface{}, query string, args ...interfac
 			query, args = maybeExpandNamedQuery(m.dbmap, query, args)
 		}
 	}
-	rows, err := e.query(query, args...)
+	rows, err := e.Query(query, args...)
 	if err != nil {
 		return err
 	}
@@ -248,7 +248,7 @@ func rawselect(m *DbMap, exec SqlExecutor, i interface{}, query string,
 	}
 
 	// Run the query
-	rows, err := exec.query(query, args...)
+	rows, err := exec.Query(query, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/transaction.go
+++ b/transaction.go
@@ -176,7 +176,7 @@ func (t *Transaction) Prepare(query string) (*sql.Stmt, error) {
 	return t.tx.Prepare(query)
 }
 
-func (t *Transaction) queryRow(query string, args ...interface{}) *sql.Row {
+func (t *Transaction) QueryRow(query string, args ...interface{}) *sql.Row {
 	if t.dbmap.logger != nil {
 		now := time.Now()
 		defer t.dbmap.trace(now, query, args...)
@@ -184,7 +184,7 @@ func (t *Transaction) queryRow(query string, args ...interface{}) *sql.Row {
 	return t.tx.QueryRow(query, args...)
 }
 
-func (t *Transaction) query(query string, args ...interface{}) (*sql.Rows, error) {
+func (t *Transaction) Query(query string, args ...interface{}) (*sql.Rows, error) {
 	if t.dbmap.logger != nil {
 		now := time.Now()
 		defer t.dbmap.trace(now, query, args...)


### PR DESCRIPTION
This is minor change that gives more flexibility when working with gorp in test environments. In reference to #158 