### PR TITLE
[update] bindplan sticked with a columnfilter

### DIFF
--- a/db.go
+++ b/db.go
@@ -183,7 +183,7 @@ func (m *DbMap) AddTableWithNameAndSchema(i interface{}, schema string, name str
 		}
 	}
 
-	tmap := &TableMap{gotype: t, TableName: name, SchemaName: schema, dbmap: m}
+	tmap := NewTableMap(t, name, schema, m)
 	var primaryKey []*ColumnMap
 	tmap.Columns, primaryKey = m.readStructColumns(t)
 	m.tables = append(m.tables, tmap)

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -1586,6 +1586,21 @@ func TestColumnFilter(t *testing.T) {
 	if inv2.IsPaid {
 		t.Error("IsPaid shouldn't have been updated")
 	}
+
+	// update isPaid field only
+	_updateColumns(dbmap, func(col *gorp.ColumnMap) bool {
+		return col.ColumnName == "IsPaid"
+	}, inv1)
+
+	inv2 = &Invoice{}
+	inv2 = _get(dbmap, inv2, inv1.Id).(*Invoice)
+	if inv2.Memo != "c" {
+		t.Errorf("Expected column to be updated (%#v)", inv2)
+	}
+	if !inv2.IsPaid {
+		t.Error("IsPaid should have been updated")
+	}
+
 }
 
 func TestTypeConversionExample(t *testing.T) {


### PR DESCRIPTION
This patch sticked a updatePlan to a column filter. So if you used two different column filters for update, it will store two updatePlan into DbMap. But that would be a problem to your design if you use thousands of column filters, which is unlikely happened.

Reason: when updating specific columns of a table, the current approach sticks all column filters to a single bindPlan, which makes it only work for the first one. However, generating updatePlan on-the-fly sounds inefficient, instead sticking a column filter to it's own updatePlan sounds like a good trade-off.

related issues: #308, #325 