### PR TITLE
JSON serialization support

### DIFF
--- a/column.go
+++ b/column.go
@@ -42,6 +42,7 @@ type ColumnMap struct {
 	isPK       bool
 	isAutoIncr bool
 	isNotNull  bool
+	isJSON     bool
 }
 
 // Rename allows you to specify the column name in the table

--- a/db.go
+++ b/db.go
@@ -15,6 +15,7 @@ import (
 	"bytes"
 	"database/sql"
 	"database/sql/driver"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -259,6 +260,7 @@ func (m *DbMap) readStructColumns(t reflect.Type) (cols []*ColumnMap, primaryKey
 			var isAuto bool
 			var isPK bool
 			var isNotNull bool
+			var isJSON bool
 			for _, argString := range cArguments[1:] {
 				argString = strings.TrimSpace(argString)
 				arg := strings.SplitN(argString, ":", 2)
@@ -288,6 +290,8 @@ func (m *DbMap) readStructColumns(t reflect.Type) (cols []*ColumnMap, primaryKey
 					isAuto = true
 				case "notnull":
 					isNotNull = true
+				case "json":
+					isJSON = true
 				default:
 					panic(fmt.Sprintf("Unrecognized tag option for field %v: %v", f.Name, arg))
 				}
@@ -311,6 +315,9 @@ func (m *DbMap) readStructColumns(t reflect.Type) (cols []*ColumnMap, primaryKey
 				if useHolder {
 					value = scanner.Holder
 					gotype = reflect.TypeOf(value)
+					if isJSON {
+						panic(fmt.Sprintf("gorp: custom scanner defined for json field %v", f.Name))
+					}
 				}
 			}
 			if typer, ok := value.(SqlTyper); ok {
@@ -323,6 +330,10 @@ func (m *DbMap) readStructColumns(t reflect.Type) (cols []*ColumnMap, primaryKey
 					gotype = reflect.TypeOf(v)
 				}
 			}
+			if isJSON { // TODO: not sure if this check is in good place
+				value = &json.RawMessage{}
+				gotype = reflect.TypeOf(value)
+			}
 			cm := &ColumnMap{
 				ColumnName:   columnName,
 				DefaultValue: defaultValue,
@@ -332,6 +343,7 @@ func (m *DbMap) readStructColumns(t reflect.Type) (cols []*ColumnMap, primaryKey
 				isPK:         isPK,
 				isAutoIncr:   isAuto,
 				isNotNull:    isNotNull,
+				isJSON:       isJSON,
 				MaxSize:      maxSize,
 			}
 			if isPK {

--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -54,7 +54,7 @@ func (d MySQLDialect) ToSqlType(val reflect.Type, maxsize int, isAutoIncr bool) 
 	case reflect.Float64, reflect.Float32:
 		return "double"
 	case reflect.Slice:
-		if val.Elem().Kind() == reflect.Uint8 {
+		if val.Elem().Kind() == reflect.Uint8 && val.Name() != "RawMessage" { // TODO: meh
 			return "mediumblob"
 		}
 	}
@@ -68,6 +68,8 @@ func (d MySQLDialect) ToSqlType(val reflect.Type, maxsize int, isAutoIncr bool) 
 		return "tinyint"
 	case "Time":
 		return "datetime"
+	case "RawMessage":
+		return "json"
 	}
 
 	if maxsize < 1 {

--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -25,6 +25,9 @@ type MySQLDialect struct {
 
 	// Encoding is the character encoding to use for created tables
 	Encoding string
+
+	// Use JSON type for json taged fields, available since MySQL 5.7.8
+	UseJSONSqlType bool
 }
 
 func (d MySQLDialect) QuerySuffix() string { return ";" }
@@ -69,7 +72,10 @@ func (d MySQLDialect) ToSqlType(val reflect.Type, maxsize int, isAutoIncr bool) 
 	case "Time":
 		return "datetime"
 	case "RawMessage":
-		return "json"
+		if d.UseJSONSqlType {
+			return "json"
+		}
+		return "mediumblob"
 	}
 
 	if maxsize < 1 {

--- a/gorp.go
+++ b/gorp.go
@@ -335,6 +335,16 @@ func toType(i interface{}) (reflect.Type, error) {
 	return t, nil
 }
 
+func hasTag(sf reflect.StructField, name string) bool {
+	all_tags := strings.Split(sf.Tag.Get("db"), ",")
+	for _, i := range all_tags {
+		if i == name {
+			return true
+		}
+	}
+	return false
+}
+
 type foundTable struct {
 	table   *TableMap
 	dynName *string

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -89,8 +89,13 @@ type InvoiceTag struct {
 	Created  int64 `db:"myCreated"`
 	Updated  int64 `db:"date_updated"`
 	Memo     string
-	PersonId int64 `db:"person_id"`
-	IsPaid   bool  `db:"is_Paid"`
+	PersonId int64                `db:"person_id"`
+	IsPaid   bool                 `db:"is_Paid"`
+	Address  *InvoiceAddressField `db:",json"`
+}
+type InvoiceAddressField struct {
+	City string
+	Zip  int32
 }
 
 func (me *InvoiceTag) GetId() int64 { return me.Id }
@@ -98,6 +103,7 @@ func (me *InvoiceTag) Rand() {
 	me.Memo = fmt.Sprintf("random %d", rand.Int63())
 	me.Created = rand.Int63()
 	me.Updated = rand.Int63()
+	me.Address = &InvoiceAddressField{fmt.Sprintf("random %d", rand.Int63()), rand.Int31()}
 }
 
 // See: https://github.com/go-gorp/gorp/issues/175
@@ -1476,8 +1482,11 @@ func TestCrud(t *testing.T) {
 	inv := &Invoice{0, 100, 200, "first order", 0, true}
 	testCrudInternal(t, dbmap, inv)
 
-	invtag := &InvoiceTag{0, 300, 400, "some order", 33, false}
+	invtag := &InvoiceTag{0, 300, 400, "some order", 33, false, &InvoiceAddressField{"Beverly Hills", 90210}}
 	testCrudInternal(t, dbmap, invtag)
+
+	invniljson := &InvoiceTag{0, 990, 231, "unadressed order", 76, false, nil}
+	testCrudInternal(t, dbmap, invniljson)
 
 	foo := &AliasTransientField{BarStr: "some bar"}
 	testCrudInternal(t, dbmap, foo)

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -2639,9 +2639,9 @@ func connect(driver string) *sql.DB {
 func dialectAndDriver() (gorp.Dialect, string) {
 	switch os.Getenv("GORP_TEST_DIALECT") {
 	case "mysql":
-		return gorp.MySQLDialect{"InnoDB", "UTF8"}, "mymysql"
+		return gorp.MySQLDialect{"InnoDB", "UTF8", false}, "mymysql"
 	case "gomysql":
-		return gorp.MySQLDialect{"InnoDB", "UTF8"}, "mysql"
+		return gorp.MySQLDialect{"InnoDB", "UTF8", false}, "mysql"
 	case "postgres":
 		return gorp.PostgresDialect{}, "postgres"
 	case "sqlite":

--- a/json.go
+++ b/json.go
@@ -8,15 +8,15 @@ import (
 
 func newJsonScanner(target interface{}) CustomScanner {
 	return CustomScanner{
-		Holder: &json.RawMessage{},
+		Holder: new([]byte),
 		Target: target,
 		Binder: func(holder, target interface{}) error {
-			sptr := holder.(*json.RawMessage)
+			sptr := holder.(*[]byte)
 			if *sptr == nil {
 				target_value := reflect.ValueOf(target).Elem()
 				target_type := target_value.Type()
 				if target_type.Kind() != reflect.Ptr {
-					return fmt.Errorf("gorp: select of json null value required pointer struct field, got %s", target_type.String())
+					return fmt.Errorf("gorp: select of json null value requires pointer struct field, got %s", target_type.String())
 				}
 				target_value.Set(reflect.Zero(target_type))
 				return nil

--- a/json.go
+++ b/json.go
@@ -1,0 +1,28 @@
+package gorp
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+)
+
+func newJsonScanner(target interface{}) CustomScanner {
+	return CustomScanner{
+		Holder: &json.RawMessage{},
+		Target: target,
+		Binder: func(holder, target interface{}) error {
+			sptr := holder.(*json.RawMessage)
+			if *sptr == nil {
+				target_value := reflect.ValueOf(target).Elem()
+				target_type := target_value.Type()
+				if target_type.Kind() != reflect.Ptr {
+					return fmt.Errorf("gorp: select of json null value required pointer struct field, got %s", target_type.String())
+				}
+				target_value.Set(reflect.Zero(target_type))
+				return nil
+			}
+			err := json.Unmarshal(*sptr, target)
+			return err
+		},
+	}
+}

--- a/select.go
+++ b/select.go
@@ -330,7 +330,7 @@ func rawselect(m *DbMap, exec SqlExecutor, i interface{}, query string,
 				scanner, ok := conv.FromDb(target)
 				if ok {
 					if isJSON {
-						return nil, fmt.Errorf("gorp: custom scanner defined for json field: %v", f.Type().FieldByIndex(colToFieldIndex[x]).Name)
+						return nil, fmt.Errorf("gorp: custom scanner defined for json field: %v", t.FieldByIndex(colToFieldIndex[x]).Name)
 					}
 					target = scanner.Holder
 					custScan = append(custScan, scanner)

--- a/select.go
+++ b/select.go
@@ -13,7 +13,6 @@ package gorp
 
 import (
 	"database/sql"
-	"encoding/json"
 	"fmt"
 	"reflect"
 )
@@ -339,24 +338,7 @@ func rawselect(m *DbMap, exec SqlExecutor, i interface{}, query string,
 			}
 
 			if isJSON {
-				scanner := CustomScanner{
-					Holder: &json.RawMessage{},
-					Target: target,
-					Binder: func(holder, target interface{}) error {
-						sptr := holder.(*json.RawMessage)
-						if *sptr == nil {
-							target_value := reflect.ValueOf(target).Elem()
-							target_type := target_value.Type()
-							if target_type.Kind() != reflect.Ptr {
-								return fmt.Errorf("gorp: select of json null value required pointer struct field, got %s", target_type.String())
-							}
-							target_value.Set(reflect.Zero(target_type))
-							return nil
-						}
-						err := json.Unmarshal(*sptr, target)
-						return err
-					},
-				}
+				scanner := newJsonScanner(target)
 				target = scanner.Holder
 				custScan = append(custScan, scanner)
 			}

--- a/table_bindings.go
+++ b/table_bindings.go
@@ -13,6 +13,7 @@ package gorp
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"sync"
@@ -77,6 +78,13 @@ func (plan *bindPlan) createBindInstance(elem reflect.Value, conv TypeConverter)
 				val, err = conv.ToDb(val)
 				if err != nil {
 					return bindInstance{}, err
+				}
+			}
+			sf, _ := elem.Type().FieldByName(k)
+			if hasTag(sf, "json") {
+				val, err = json.Marshal(val)
+				if err != nil {
+					return bindInstance{}, fmt.Errorf("gorp: createBindInstance json.Marshal error for %s: %s", k, err)
 				}
 			}
 			bi.args = append(bi.args, val)

--- a/table_bindings.go
+++ b/table_bindings.go
@@ -82,10 +82,11 @@ func (plan *bindPlan) createBindInstance(elem reflect.Value, conv TypeConverter)
 			}
 			sf, _ := elem.Type().FieldByName(k)
 			if hasTag(sf, "json") {
-				val, err = json.Marshal(val)
+				bytez, err := json.Marshal(val)
 				if err != nil {
 					return bindInstance{}, fmt.Errorf("gorp: createBindInstance json.Marshal error for %s: %s", k, err)
 				}
+				val = append([]byte(nil), bytez...) // workaround for sqlite issue caused by cgo bug https://github.com/golang/go/issues/18184
 			}
 			bi.args = append(bi.args, val)
 		}


### PR DESCRIPTION
This patch adds support for storing struct fields in database as serialized JSON.
I've tested it against MySQL and SQLite.

Simplistic example:

    type JsonRow struct {
        Id   int
        Data *JsonField `db:"Data,json"`
    }

    type JsonField struct {
        Name string
        Age  int
    }

    func main() {
        db, _ := sql.Open("mymysql", "...")
        dbmap := &gorp.DbMap{Db: db, Dialect: gorp.MySQLDialect{"InnoDB", "UTF8"}}
        dbmap.AddTableWithName(JsonRow{}, "json_test").SetKeys(true, "Id")
        dbmap.CreateTables()

        dbmap.Insert(&JsonRow{10, &JsonField{Name: "Karol", Age: 44}})
        dbmap.Insert(&JsonRow{0, &JsonField{Name: "Radek", Age: 23}})
        dbmap.Insert(&JsonRow{0, nil})

        var rows []JsonRow
        _, err := dbmap.Select(&rows, "SELECT * FROM json_test")
        fmt.Println(err)
        for i, v := range rows {
            fmt.Printf("> %d: %d %+v\n", i, v.Id, v.Data)
        }
    }
