### PR TITLE
Support for strfmt.DateTime to datetime mapping to support go-swagger generated models

### DIFF
--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
-	"log"
 )
 
 // Implementation of Dialect for MySQL databases.

--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"log"
 )
 
 // Implementation of Dialect for MySQL databases.
@@ -58,7 +59,7 @@ func (d MySQLDialect) ToSqlType(val reflect.Type, maxsize int, isAutoIncr bool) 
 			return "mediumblob"
 		}
 	}
-
+	log.Println(val.Name())
 	switch val.Name() {
 	case "NullInt64":
 		return "bigint"
@@ -67,6 +68,8 @@ func (d MySQLDialect) ToSqlType(val reflect.Type, maxsize int, isAutoIncr bool) 
 	case "NullBool":
 		return "tinyint"
 	case "Time":
+		return "datetime"
+	case "DateTime":
 		return "datetime"
 	}
 

--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -59,7 +59,6 @@ func (d MySQLDialect) ToSqlType(val reflect.Type, maxsize int, isAutoIncr bool) 
 			return "mediumblob"
 		}
 	}
-	log.Println(val.Name())
 	switch val.Name() {
 	case "NullInt64":
 		return "bigint"

--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -19,7 +19,6 @@ import (
 
 // Implementation of Dialect for MySQL databases.
 type MySQLDialect struct {
-
 	// Engine is the storage engine to use "InnoDB" vs "MyISAM" for example
 	Engine string
 
@@ -65,10 +64,9 @@ func (d MySQLDialect) ToSqlType(val reflect.Type, maxsize int, isAutoIncr bool) 
 		return "double"
 	case "NullBool":
 		return "tinyint"
-	case "Time":
+	case "Time", "DateTime":
 		return "datetime"
-	case "DateTime":
-		return "datetime"
+
 	}
 
 	if maxsize < 1 {

--- a/dialect_mysql_test.go
+++ b/dialect_mysql_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/go-gorp/gorp"
+	"github.com/go-openapi/strfmt"
 )
 
 var _ = Describe("MySQLDialect", func() {
@@ -61,6 +62,7 @@ var _ = Describe("MySQLDialect", func() {
 		Entry("NullFloat64", sql.NullFloat64{}, 0, false, "double"),
 		Entry("NullBool", sql.NullBool{}, 0, false, "tinyint"),
 		Entry("Time", time.Time{}, 0, false, "datetime"),
+		Entry("DateTime", strfmt.DateTime{}, 0, false, "datetime"),
 		Entry("default-size string", "", 0, false, "varchar(255)"),
 		Entry("sized string", "", 50, false, "varchar(50)"),
 		Entry("large string", "", 1024, false, "text"),

--- a/dialect_oracle.go
+++ b/dialect_oracle.go
@@ -59,7 +59,7 @@ func (d OracleDialect) ToSqlType(val reflect.Type, maxsize int, isAutoIncr bool)
 		return "double precision"
 	case "NullBool":
 		return "boolean"
-	case "NullTime", "Time":
+	case "NullTime", "Time", "DateTime":
 		return "timestamp with time zone"
 	}
 

--- a/dialect_postgres.go
+++ b/dialect_postgres.go
@@ -56,7 +56,7 @@ func (d PostgresDialect) ToSqlType(val reflect.Type, maxsize int, isAutoIncr boo
 		return "double precision"
 	case "NullBool":
 		return "boolean"
-	case "Time", "NullTime":
+	case "Time", "NullTime","DateTime":
 		return "timestamp with time zone"
 	}
 

--- a/dialect_sqlite.go
+++ b/dialect_sqlite.go
@@ -47,6 +47,8 @@ func (d SqliteDialect) ToSqlType(val reflect.Type, maxsize int, isAutoIncr bool)
 		return "integer"
 	case "Time":
 		return "datetime"
+	case "DateTime":
+		return "datetime"
 	}
 
 	if maxsize < 1 {

--- a/dialect_sqlite.go
+++ b/dialect_sqlite.go
@@ -45,10 +45,9 @@ func (d SqliteDialect) ToSqlType(val reflect.Type, maxsize int, isAutoIncr bool)
 		return "real"
 	case "NullBool":
 		return "integer"
-	case "Time":
+	case "Time", "DateTime":
 		return "datetime"
-	case "DateTime":
-		return "datetime"
+
 	}
 
 	if maxsize < 1 {

--- a/dialect_sqlserver.go
+++ b/dialect_sqlserver.go
@@ -66,7 +66,7 @@ func (d SqlServerDialect) ToSqlType(val reflect.Type, maxsize int, isAutoIncr bo
 		return "float(53)"
 	case "NullBool":
 		return "bit"
-	case "NullTime", "Time":
+	case "NullTime", "Time","DateTime":
 		if d.Version == "2005" {
 			return "datetime"
 		}


### PR DESCRIPTION
Digging gorp, and in my pursuit of using it to connect to a legacy DB, i found that the swagger generated models, didn't match up with strfmt.DateTime (what go-swagger generates strings of time date-time)... So i added it. 


In swagger yaml use this...

```yaml
  legacy_user:
    type: object
    properties:
      id:
        type: integer
        format: int64
        x-go-custom-tag: db:"id"
      last_login:
        type: string
        format: date-time
        x-go-custom-tag: db:"last_login"
```