### PR TITLE
Fix SqlTyper

### DIFF
--- a/db.go
+++ b/db.go
@@ -18,6 +18,7 @@ import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
+	"log"
 	"reflect"
 	"strconv"
 	"strings"
@@ -323,6 +324,9 @@ func (m *DbMap) readStructColumns(t reflect.Type) (cols []*ColumnMap, primaryKey
 				}
 			}
 			if typer, ok := value.(SqlTyper); ok {
+				gotype = reflect.TypeOf(typer.SqlType())
+			} else if typer, ok := value.(legacySqlTyper); ok {
+				log.Printf("Deprecation Warning: update your SqlType methods to return a driver.Value")
 				gotype = reflect.TypeOf(typer.SqlType())
 			} else if valuer, ok := value.(driver.Valuer); ok {
 				// Only check for driver.Valuer if SqlTyper wasn't

--- a/gorp.go
+++ b/gorp.go
@@ -51,6 +51,12 @@ func (os OracleString) Value() (driver.Value, error) {
 // it returns nil for its empty value, it needs to implement SqlTyper
 // to have its column type detected properly during table creation.
 type SqlTyper interface {
+	SqlType() driver.Value
+}
+
+// legacySqlTyper prevents breaking clients who depended on the previous
+// SqlTyper interface
+type legacySqlTyper interface {
 	SqlType() driver.Valuer
 }
 


### PR DESCRIPTION
The `SqlType` type should be returning a `driver.Value` instead of `driver.Valuer`

https://github.com/go-gorp/gorp/blob/659d466222f6a201e44cfeff05813fa6be8409cd/db.go#L326

The way to get it working now is to do something like this

``` go
type IntValuer int

func (IntValue) Value() (driver.Value, error) {
  return nil, nil
}

type CustomType int

func (CustomType) SqlType() driver.Valuer {
  return IntValuer(0)
}
```
This will continue working with the proposed change.
