### PR TITLE
Check error if rows.Next returns false.

### DIFF
--- a/dialect_postgres_test.go
+++ b/dialect_postgres_test.go
@@ -30,6 +30,10 @@ var _ = Describe("PostgresDialect", func() {
 		dialect         gorp.PostgresDialect
 	)
 
+	BeforeEach(func() {
+		lowercasefields = false
+	})
+
 	JustBeforeEach(func() {
 		dialect = gorp.PostgresDialect{
 			LowercaseFields: lowercasefields,

--- a/gorp_go18_test.go
+++ b/gorp_go18_test.go
@@ -16,9 +16,10 @@ package gorp_test
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // Drivers that don't support cancellation.
@@ -47,12 +48,12 @@ func TestWithNotCanceledContext(t *testing.T) {
 func TestWithCanceledContext(t *testing.T) {
 	dialect, driver := dialectAndDriver()
 	if unsupportedDrivers[driver] {
-		t.Skip("Cancellation is not yet supported by all drivers. Not known to be supported in %s.", driver)
+		t.Skipf("Cancellation is not yet supported by all drivers. Not known to be supported in %s.", driver)
 	}
 
 	sleepDialect, ok := dialect.(SleepDialect)
 	if !ok {
-		t.Skip("Sleep is not supported in all dialects. Not known to be supported in %s.", driver)
+		t.Skipf("Sleep is not supported in all dialects. Not known to be supported in %s.", driver)
 	}
 
 	dbmap := initDbMap()

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -1766,15 +1766,15 @@ func TestSelectVal(t *testing.T) {
 	// SelectFloat
 	f64 := selectFloat(dbmap, "select "+columnName(dbmap, TableWithNull{}, "Float64")+" from "+tableName(dbmap, TableWithNull{})+" where "+columnName(dbmap, TableWithNull{}, "Str")+"='abc'")
 	if f64 != 32.2 {
-		t.Errorf("float64 %d != 32.2", f64)
+		t.Errorf("float64 %f != 32.2", f64)
 	}
 	f64 = selectFloat(dbmap, "select min("+columnName(dbmap, TableWithNull{}, "Float64")+") from "+tableName(dbmap, TableWithNull{}))
 	if f64 != 32.2 {
-		t.Errorf("float64 min %d != 32.2", f64)
+		t.Errorf("float64 min %f != 32.2", f64)
 	}
 	f64 = selectFloat(dbmap, "select count(*) from "+tableName(dbmap, TableWithNull{})+" where "+columnName(dbmap, TableWithNull{}, "Str")+"="+bindVar, "asdfasdf")
 	if f64 != 0 {
-		t.Errorf("float64 no rows %d != 0", f64)
+		t.Errorf("float64 no rows %f != 0", f64)
 	}
 
 	// SelectNullFloat
@@ -1885,13 +1885,13 @@ func TestNullTime(t *testing.T) {
 		}}
 	err := dbmap.Insert(ent)
 	if err != nil {
-		t.Error("failed insert on %s", err.Error())
+		t.Errorf("failed insert on %s", err.Error())
 	}
 	err = dbmap.SelectOne(ent, `select * from nulltime_test where `+columnName(dbmap, WithNullTime{}, "Id")+`=:Id`, map[string]interface{}{
 		"Id": ent.Id,
 	})
 	if err != nil {
-		t.Error("failed select on %s", err.Error())
+		t.Errorf("failed select on %s", err.Error())
 	}
 	if ent.Time.Valid {
 		t.Error("gorp.NullTime returns valid but expected null.")
@@ -1907,13 +1907,13 @@ func TestNullTime(t *testing.T) {
 		}}
 	err = dbmap.Insert(ent)
 	if err != nil {
-		t.Error("failed insert on %s", err.Error())
+		t.Errorf("failed insert on %s", err.Error())
 	}
 	err = dbmap.SelectOne(ent, `select * from nulltime_test where `+columnName(dbmap, WithNullTime{}, "Id")+`=:Id`, map[string]interface{}{
 		"Id": ent.Id,
 	})
 	if err != nil {
-		t.Error("failed select on %s", err.Error())
+		t.Errorf("failed select on %s", err.Error())
 	}
 	if !ent.Time.Valid {
 		t.Error("gorp.NullTime returns invalid but expected valid.")

--- a/select.go
+++ b/select.go
@@ -169,6 +169,9 @@ func selectVal(e SqlExecutor, holder interface{}, query string, args ...interfac
 	defer rows.Close()
 
 	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return err
+		}
 		return sql.ErrNoRows
 	}
 


### PR DESCRIPTION
Per https://golang.org/pkg/database/sql/#Rows.Next,
> returns true on success, or false if there is no next result row or an error
> happened while preparing it. Err should be consulted to distinguish between
> the two cases.

Fixes #364.