### PR TITLE
Added sql-migrate to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ See the `TestWithEmbeddedStruct` function in `gorp_test.go` for a full example.
 
 Automatically create / drop registered tables.  This is useful for unit tests
 but is entirely optional.  You can of course use gorp with tables created manually,
-or with a separate migration tool (like [goose](https://bitbucket.org/liamstask/goose) or [migrate](https://github.com/mattes/migrate)).
+or with a separate migration tool (like [sql-migrate](https://github.com/rubenv/sql-migrate), [goose](https://bitbucket.org/liamstask/goose) or [migrate](https://github.com/mattes/migrate)).
 
 ```go
 // create all registered tables


### PR DESCRIPTION
Could we add [sql-migrate](https://github.com/rubenv/sql-migrate) to the README as well?

Goose has been unmaintained and `sql-migrate` is built using gorp, so that's a good showcase!