### PR TITLE
Fix: Each updateFilter must have corresponding bindPlan

### DIFF
--- a/db.go
+++ b/db.go
@@ -296,7 +296,7 @@ func (m *DbMap) readStructColumns(t reflect.Type) (cols []*ColumnMap, primaryKey
 					isPK = true
 				case "autoincrement":
 					isAuto = true
-				case "notnull":
+				case "notnull", "not null":
 					isNotNull = true
 				default:
 					panic(fmt.Sprintf("Unrecognized tag option for field %v: %v", f.Name, arg))

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -1586,8 +1586,37 @@ func TestColumnFilter(t *testing.T) {
 	if inv2.IsPaid {
 		t.Error("IsPaid shouldn't have been updated")
 	}
-}
 
+	inv1.Memo = "d"
+	inv1.IsPaid = true
+	_updateColumns(dbmap, func(col *gorp.ColumnMap) bool {
+		return col.ColumnName == "IsPaid"
+	}, inv1)
+
+	inv3 := &Invoice{}
+	inv3 = _get(dbmap, inv3, inv1.Id).(*Invoice)
+	if inv3.Memo != "c" {
+		t.Errorf("Expected column to be updated (%#v)", inv3)
+	}
+	if !inv3.IsPaid {
+		t.Error("IsPaid should now be updated")
+	}
+
+	// classic update should work
+	inv1.Memo = "e"
+	inv1.IsPaid = false
+	_update(dbmap, inv1)
+
+	inv4 := &Invoice{}
+	inv4 = _get(dbmap, inv4, inv1.Id).(*Invoice)
+	if inv4.Memo != "e" {
+		t.Errorf("Expected column to be updated (%#v)", inv4)
+	}
+	if inv4.IsPaid {
+		t.Error("IsPaid should be false again")
+	}
+
+}
 func TestTypeConversionExample(t *testing.T) {
 	dbmap := initDbMap()
 	defer dropAndClose(dbmap)

--- a/table.go
+++ b/table.go
@@ -26,12 +26,13 @@ type TableMap struct {
 	SchemaName     string
 	gotype         reflect.Type
 	Columns        []*ColumnMap
-	keys           []*ColumnMap
+	keys           []*ColumnMap // primary key column; can be autoIncrement
 	indexes        []*IndexMap
 	uniqueTogether [][]string
 	version        *ColumnMap
 	insertPlan     bindPlan
 	updatePlan     bindPlan
+	colFilter      ColumnFilter // different column filters lead to different updatePlans
 	deletePlan     bindPlan
 	getPlan        bindPlan
 	dbmap          *DbMap

--- a/table_bindings.go
+++ b/table_bindings.go
@@ -169,8 +169,16 @@ func (t *TableMap) bindInsert(elem reflect.Value) (bindInstance, error) {
 }
 
 func (t *TableMap) bindUpdate(elem reflect.Value, colFilter ColumnFilter) (bindInstance, error) {
+
 	if colFilter == nil {
+		if t.colFilter != nil {
+			t.updatePlan = bindPlan{}
+		}
+		t.colFilter = nil
 		colFilter = acceptAllFilter
+	} else {
+		t.updatePlan = bindPlan{} // a new bindPlan everytime; since we cannot compare colFilter funcs
+		t.colFilter = colFilter
 	}
 
 	plan := &t.updatePlan


### PR DESCRIPTION
Current behavior:

I set an updateFilter - then I update => works.
Now I remove the updateFilter - then I update => broken - still only the columns from previous updateFilter are updated. Reason: the bindPlan does not reflect the removal of the update filter.

I added tests, to demonstrate the fixed behavior.

Kind regards
  Peter