### PR TITLE
Convert slice arguments in mappers into flat values

### DIFF
--- a/db.go
+++ b/db.go
@@ -982,6 +982,10 @@ func expandSliceArgs(query *string, args ...interface{}) {
 				continue
 			}
 
+			if len(replacements) == 0 {
+				continue
+			}
+
 			*query = strings.Replace(*query, fmt.Sprintf(":%s", key), strings.Join(replacements, ","), -1)
 		}
 	}

--- a/db.go
+++ b/db.go
@@ -45,6 +45,57 @@ type DbMap struct {
 
 	TypeConverter TypeConverter
 
+	// ExpandSlices when enabled will convert slice arguments in mappers into flat
+	// values. It will modify the query, adding more placeholders, and the mapper,
+	// adding each item of the slice as a new unique entry in the mapper. For
+	// example, given the scenario bellow:
+	//
+	//     dbmap.Select(&output, "SELECT 1 FROM example WHERE id IN (:IDs)", map[string]interface{}{
+	//       "IDs": []int64{1, 2, 3},
+	//     })
+	//
+	// The executed query would be:
+	//
+	//     SELECT 1 FROM example WHERE id IN (:IDs0,:IDs1,:IDs2)
+	//
+	// With the mapper:
+	//
+	//     map[string]interface{}{
+	//       "IDs":  []int64{1, 2, 3},
+	//       "IDs0": int64(1),
+	//       "IDs1": int64(2),
+	//       "IDs2": int64(3),
+	//     }
+	//
+	// It is also flexible for custom slice types. The value just need to
+	// implement stringer or numberer interfaces.
+	//
+	//     type CustomValue string
+	//
+	//     const (
+	//       CustomValueHey CustomValue = "hey"
+	//       CustomValueOh  CustomValue = "oh"
+	//     )
+	//
+	//     type CustomValues []CustomValue
+	//
+	//     func (c CustomValues) ToStringSlice() []string {
+	//       values := make([]string, len(c))
+	//       for i := range c {
+	//         values[i] = string(c[i])
+	//       }
+	//       return values
+	//     }
+	//
+	//     func query() {
+	//       // ...
+	//       result, err := dbmap.Select(&output, "SELECT 1 FROM example WHERE value IN (:Values)", map[string]interface{}{
+	//         "Values": CustomValues([]CustomValue{CustomValueHey}),
+	//       })
+	//       // ...
+	//     }
+	ExpandSliceArgs bool
+
 	tables        []*TableMap
 	tablesDynamic map[string]*TableMap // tables that use same go-struct and different db table names
 	logger        GorpLogger
@@ -605,12 +656,20 @@ func (m *DbMap) Get(i interface{}, keys ...interface{}) (interface{}, error) {
 //
 // i does NOT need to be registered with AddTable()
 func (m *DbMap) Select(i interface{}, query string, args ...interface{}) ([]interface{}, error) {
+	if m.ExpandSliceArgs {
+		expandSliceArgs(&query, args...)
+	}
+
 	return hookedselect(m, m, i, query, args...)
 }
 
 // Exec runs an arbitrary SQL statement.  args represent the bind parameters.
 // This is equivalent to running:  Exec() using database/sql
 func (m *DbMap) Exec(query string, args ...interface{}) (sql.Result, error) {
+	if m.ExpandSliceArgs {
+		expandSliceArgs(&query, args...)
+	}
+
 	if m.logger != nil {
 		now := time.Now()
 		defer m.trace(now, query, args...)
@@ -620,36 +679,64 @@ func (m *DbMap) Exec(query string, args ...interface{}) (sql.Result, error) {
 
 // SelectInt is a convenience wrapper around the gorp.SelectInt function
 func (m *DbMap) SelectInt(query string, args ...interface{}) (int64, error) {
+	if m.ExpandSliceArgs {
+		expandSliceArgs(&query, args...)
+	}
+
 	return SelectInt(m, query, args...)
 }
 
 // SelectNullInt is a convenience wrapper around the gorp.SelectNullInt function
 func (m *DbMap) SelectNullInt(query string, args ...interface{}) (sql.NullInt64, error) {
+	if m.ExpandSliceArgs {
+		expandSliceArgs(&query, args...)
+	}
+
 	return SelectNullInt(m, query, args...)
 }
 
 // SelectFloat is a convenience wrapper around the gorp.SelectFloat function
 func (m *DbMap) SelectFloat(query string, args ...interface{}) (float64, error) {
+	if m.ExpandSliceArgs {
+		expandSliceArgs(&query, args...)
+	}
+
 	return SelectFloat(m, query, args...)
 }
 
 // SelectNullFloat is a convenience wrapper around the gorp.SelectNullFloat function
 func (m *DbMap) SelectNullFloat(query string, args ...interface{}) (sql.NullFloat64, error) {
+	if m.ExpandSliceArgs {
+		expandSliceArgs(&query, args...)
+	}
+
 	return SelectNullFloat(m, query, args...)
 }
 
 // SelectStr is a convenience wrapper around the gorp.SelectStr function
 func (m *DbMap) SelectStr(query string, args ...interface{}) (string, error) {
+	if m.ExpandSliceArgs {
+		expandSliceArgs(&query, args...)
+	}
+
 	return SelectStr(m, query, args...)
 }
 
 // SelectNullStr is a convenience wrapper around the gorp.SelectNullStr function
 func (m *DbMap) SelectNullStr(query string, args ...interface{}) (sql.NullString, error) {
+	if m.ExpandSliceArgs {
+		expandSliceArgs(&query, args...)
+	}
+
 	return SelectNullStr(m, query, args...)
 }
 
 // SelectOne is a convenience wrapper around the gorp.SelectOne function
 func (m *DbMap) SelectOne(holder interface{}, query string, args ...interface{}) error {
+	if m.ExpandSliceArgs {
+		expandSliceArgs(&query, args...)
+	}
+
 	return SelectOne(m, m, holder, query, args...)
 }
 
@@ -764,6 +851,10 @@ func (m *DbMap) tableForPointer(ptr interface{}, checkPK bool) (*TableMap, refle
 }
 
 func (m *DbMap) QueryRow(query string, args ...interface{}) *sql.Row {
+	if m.ExpandSliceArgs {
+		expandSliceArgs(&query, args...)
+	}
+
 	if m.logger != nil {
 		now := time.Now()
 		defer m.trace(now, query, args...)
@@ -772,6 +863,10 @@ func (m *DbMap) QueryRow(query string, args ...interface{}) *sql.Row {
 }
 
 func (m *DbMap) Query(q string, args ...interface{}) (*sql.Rows, error) {
+	if m.ExpandSliceArgs {
+		expandSliceArgs(&q, args...)
+	}
+
 	if m.logger != nil {
 		now := time.Now()
 		defer m.trace(now, q, args...)
@@ -780,8 +875,114 @@ func (m *DbMap) Query(q string, args ...interface{}) (*sql.Rows, error) {
 }
 
 func (m *DbMap) trace(started time.Time, query string, args ...interface{}) {
+	if m.ExpandSliceArgs {
+		expandSliceArgs(&query, args...)
+	}
+
 	if m.logger != nil {
 		var margs = argsString(args...)
 		m.logger.Printf("%s%s [%s] (%v)", m.logPrefix, query, margs, (time.Now().Sub(started)))
+	}
+}
+
+type stringer interface {
+	ToStringSlice() []string
+}
+
+type numberer interface {
+	ToInt64Slice() []int64
+}
+
+func expandSliceArgs(query *string, args ...interface{}) {
+	for _, arg := range args {
+		mapper, ok := arg.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		for key, value := range mapper {
+			var replacements []string
+
+			// add flexibility for any custom type to be convert to one of the
+			// acceptable formats.
+			if v, ok := value.(stringer); ok {
+				value = v.ToStringSlice()
+			}
+			if v, ok := value.(numberer); ok {
+				value = v.ToInt64Slice()
+			}
+
+			switch v := value.(type) {
+			case []string:
+				for id, replace := range v {
+					mapper[fmt.Sprintf("%s%d", key, id)] = replace
+					replacements = append(replacements, fmt.Sprintf(":%s%d", key, id))
+				}
+			case []uint:
+				for id, replace := range v {
+					mapper[fmt.Sprintf("%s%d", key, id)] = replace
+					replacements = append(replacements, fmt.Sprintf(":%s%d", key, id))
+				}
+			case []uint8:
+				for id, replace := range v {
+					mapper[fmt.Sprintf("%s%d", key, id)] = replace
+					replacements = append(replacements, fmt.Sprintf(":%s%d", key, id))
+				}
+			case []uint16:
+				for id, replace := range v {
+					mapper[fmt.Sprintf("%s%d", key, id)] = replace
+					replacements = append(replacements, fmt.Sprintf(":%s%d", key, id))
+				}
+			case []uint32:
+				for id, replace := range v {
+					mapper[fmt.Sprintf("%s%d", key, id)] = replace
+					replacements = append(replacements, fmt.Sprintf(":%s%d", key, id))
+				}
+			case []uint64:
+				for id, replace := range v {
+					mapper[fmt.Sprintf("%s%d", key, id)] = replace
+					replacements = append(replacements, fmt.Sprintf(":%s%d", key, id))
+				}
+			case []int:
+				for id, replace := range v {
+					mapper[fmt.Sprintf("%s%d", key, id)] = replace
+					replacements = append(replacements, fmt.Sprintf(":%s%d", key, id))
+				}
+			case []int8:
+				for id, replace := range v {
+					mapper[fmt.Sprintf("%s%d", key, id)] = replace
+					replacements = append(replacements, fmt.Sprintf(":%s%d", key, id))
+				}
+			case []int16:
+				for id, replace := range v {
+					mapper[fmt.Sprintf("%s%d", key, id)] = replace
+					replacements = append(replacements, fmt.Sprintf(":%s%d", key, id))
+				}
+			case []int32:
+				for id, replace := range v {
+					mapper[fmt.Sprintf("%s%d", key, id)] = replace
+					replacements = append(replacements, fmt.Sprintf(":%s%d", key, id))
+				}
+			case []int64:
+				for id, replace := range v {
+					mapper[fmt.Sprintf("%s%d", key, id)] = replace
+					replacements = append(replacements, fmt.Sprintf(":%s%d", key, id))
+				}
+			case []float32:
+				for id, replace := range v {
+					mapper[fmt.Sprintf("%s%d", key, id)] = replace
+					replacements = append(replacements, fmt.Sprintf(":%s%d", key, id))
+				}
+			case []float64:
+				for id, replace := range v {
+					mapper[fmt.Sprintf("%s%d", key, id)] = replace
+					replacements = append(replacements, fmt.Sprintf(":%s%d", key, id))
+				}
+			default:
+				continue
+			}
+
+			*query = strings.Replace(*query, fmt.Sprintf(":%s", key), strings.Join(replacements, ","), -1)
+		}
 	}
 }

--- a/db_test.go
+++ b/db_test.go
@@ -9,10 +9,9 @@
 // Source code and project home:
 // https://github.com/go-gorp/gorp
 
-package gorp
+package gorp_test
 
 import (
-	"reflect"
 	"testing"
 )
 
@@ -28,13 +27,12 @@ func (c customType2) ToInt64Slice() []int64 {
 	return []int64(c)
 }
 
-func TestExpandSliceArgs(t *testing.T) {
+func TestDbMap_Select_expandSliceArgs(t *testing.T) {
 	tests := []struct {
 		description string
 		query       string
 		args        []interface{}
-		wantQuery   string
-		wantArgs    []interface{}
+		wantLen     int
 	}{
 		{
 			description: "it should handle slice placeholders correctly",
@@ -73,183 +71,117 @@ AND field14 IN (:FieldFloat64List)
 					"FieldFloat64List": []float64{1, 2, 3, 4},
 				},
 			},
-			wantQuery: `
-SELECT 1 FROM crazy_table
-WHERE field1 = :Field1
-AND field2 IN (:FieldStringList0,:FieldStringList1,:FieldStringList2)
-AND field3 IN (:FieldUIntList0,:FieldUIntList1,:FieldUIntList2,:FieldUIntList3)
-AND field4 IN (:FieldUInt8List0,:FieldUInt8List1,:FieldUInt8List2,:FieldUInt8List3)
-AND field5 IN (:FieldUInt16List0,:FieldUInt16List1,:FieldUInt16List2,:FieldUInt16List3)
-AND field6 IN (:FieldUInt32List0,:FieldUInt32List1,:FieldUInt32List2,:FieldUInt32List3)
-AND field7 IN (:FieldUInt64List0,:FieldUInt64List1,:FieldUInt64List2,:FieldUInt64List3)
-AND field8 IN (:FieldIntList0,:FieldIntList1,:FieldIntList2,:FieldIntList3)
-AND field9 IN (:FieldInt8List0,:FieldInt8List1,:FieldInt8List2,:FieldInt8List3)
-AND field10 IN (:FieldInt16List0,:FieldInt16List1,:FieldInt16List2,:FieldInt16List3)
-AND field11 IN (:FieldInt32List0,:FieldInt32List1,:FieldInt32List2,:FieldInt32List3)
-AND field12 IN (:FieldInt64List0,:FieldInt64List1,:FieldInt64List2,:FieldInt64List3)
-AND field13 IN (:FieldFloat32List0,:FieldFloat32List1,:FieldFloat32List2,:FieldFloat32List3)
-AND field14 IN (:FieldFloat64List0,:FieldFloat64List1,:FieldFloat64List2,:FieldFloat64List3)
-`,
-			wantArgs: []interface{}{
-				map[string]interface{}{
-					"Field1":            123,
-					"FieldStringList":   []string{"h", "e", "y"},
-					"FieldStringList0":  "h",
-					"FieldStringList1":  "e",
-					"FieldStringList2":  "y",
-					"FieldUIntList":     []uint{1, 2, 3, 4},
-					"FieldUIntList0":    uint(1),
-					"FieldUIntList1":    uint(2),
-					"FieldUIntList2":    uint(3),
-					"FieldUIntList3":    uint(4),
-					"FieldUInt8List":    []uint8{1, 2, 3, 4},
-					"FieldUInt8List0":   uint8(1),
-					"FieldUInt8List1":   uint8(2),
-					"FieldUInt8List2":   uint8(3),
-					"FieldUInt8List3":   uint8(4),
-					"FieldUInt16List":   []uint16{1, 2, 3, 4},
-					"FieldUInt16List0":  uint16(1),
-					"FieldUInt16List1":  uint16(2),
-					"FieldUInt16List2":  uint16(3),
-					"FieldUInt16List3":  uint16(4),
-					"FieldUInt32List":   []uint32{1, 2, 3, 4},
-					"FieldUInt32List0":  uint32(1),
-					"FieldUInt32List1":  uint32(2),
-					"FieldUInt32List2":  uint32(3),
-					"FieldUInt32List3":  uint32(4),
-					"FieldUInt64List":   []uint64{1, 2, 3, 4},
-					"FieldUInt64List0":  uint64(1),
-					"FieldUInt64List1":  uint64(2),
-					"FieldUInt64List2":  uint64(3),
-					"FieldUInt64List3":  uint64(4),
-					"FieldIntList":      []int{1, 2, 3, 4},
-					"FieldIntList0":     int(1),
-					"FieldIntList1":     int(2),
-					"FieldIntList2":     int(3),
-					"FieldIntList3":     int(4),
-					"FieldInt8List":     []int8{1, 2, 3, 4},
-					"FieldInt8List0":    int8(1),
-					"FieldInt8List1":    int8(2),
-					"FieldInt8List2":    int8(3),
-					"FieldInt8List3":    int8(4),
-					"FieldInt16List":    []int16{1, 2, 3, 4},
-					"FieldInt16List0":   int16(1),
-					"FieldInt16List1":   int16(2),
-					"FieldInt16List2":   int16(3),
-					"FieldInt16List3":   int16(4),
-					"FieldInt32List":    []int32{1, 2, 3, 4},
-					"FieldInt32List0":   int32(1),
-					"FieldInt32List1":   int32(2),
-					"FieldInt32List2":   int32(3),
-					"FieldInt32List3":   int32(4),
-					"FieldInt64List":    []int64{1, 2, 3, 4},
-					"FieldInt64List0":   int64(1),
-					"FieldInt64List1":   int64(2),
-					"FieldInt64List2":   int64(3),
-					"FieldInt64List3":   int64(4),
-					"FieldFloat32List":  []float32{1, 2, 3, 4},
-					"FieldFloat32List0": float32(1),
-					"FieldFloat32List1": float32(2),
-					"FieldFloat32List2": float32(3),
-					"FieldFloat32List3": float32(4),
-					"FieldFloat64List":  []float64{1, 2, 3, 4},
-					"FieldFloat64List0": float64(1),
-					"FieldFloat64List1": float64(2),
-					"FieldFloat64List2": float64(3),
-					"FieldFloat64List3": float64(4),
-				},
-			},
+			wantLen: 1,
 		},
 		{
 			description: "it should handle slice placeholders correctly with custom types",
 			query: `
 SELECT 1 FROM crazy_table
-WHERE field1 = :Field1
-AND field2 IN (:FieldIntList)
-AND field3 IN (:FieldStringList)
+WHERE field2 IN (:FieldStringList)
+AND field12 IN (:FieldIntList)
 `,
 			args: []interface{}{
 				map[string]interface{}{
-					"Field1":          123,
-					"FieldIntList":    customType2{1, 2, 3, 4},
 					"FieldStringList": customType1{"h", "e", "y"},
+					"FieldIntList":    customType2{1, 2, 3, 4},
 				},
 			},
-			wantQuery: `
-SELECT 1 FROM crazy_table
-WHERE field1 = :Field1
-AND field2 IN (:FieldIntList0,:FieldIntList1,:FieldIntList2,:FieldIntList3)
-AND field3 IN (:FieldStringList0,:FieldStringList1,:FieldStringList2)
-`,
-			wantArgs: []interface{}{
-				map[string]interface{}{
-					"Field1":           123,
-					"FieldIntList":     customType2{1, 2, 3, 4},
-					"FieldIntList0":    int64(1),
-					"FieldIntList1":    int64(2),
-					"FieldIntList2":    int64(3),
-					"FieldIntList3":    int64(4),
-					"FieldStringList":  customType1{"h", "e", "y"},
-					"FieldStringList0": "h",
-					"FieldStringList1": "e",
-					"FieldStringList2": "y",
-				},
-			},
+			wantLen: 3,
 		},
-		{
-			description: "it should ignore empty slices",
-			query: `
-SELECT 1 FROM crazy_table
-WHERE field1 IN (:FieldIntList)
-`,
-			args: []interface{}{
-				map[string]interface{}{
-					"FieldIntList": []int64{},
-				},
-			},
-			wantQuery: `
-SELECT 1 FROM crazy_table
-WHERE field1 IN (:FieldIntList)
-`,
-			wantArgs: []interface{}{
-				map[string]interface{}{
-					"FieldIntList": []int64{},
-				},
-			},
+	}
+
+	type dataFormat struct {
+		Field1  int
+		Field2  string
+		Field3  uint
+		Field4  uint8
+		Field5  uint16
+		Field6  uint32
+		Field7  uint64
+		Field8  int
+		Field9  int8
+		Field10 int16
+		Field11 int32
+		Field12 int64
+		Field13 float32
+		Field14 float64
+	}
+
+	dbmap := newDbMap()
+	dbmap.ExpandSliceArgs = true
+	dbmap.AddTableWithName(dataFormat{}, "crazy_table")
+
+	err := dbmap.CreateTables()
+	if err != nil {
+		panic(err)
+	}
+	defer dropAndClose(dbmap)
+
+	err = dbmap.Insert(
+		&dataFormat{
+			Field1:  123,
+			Field2:  "h",
+			Field3:  1,
+			Field4:  1,
+			Field5:  1,
+			Field6:  1,
+			Field7:  1,
+			Field8:  1,
+			Field9:  1,
+			Field10: 1,
+			Field11: 1,
+			Field12: 1,
+			Field13: 1,
+			Field14: 1,
 		},
-		{
-			description: "it should ignore non-mappers",
-			query: `
-SELECT 1 FROM crazy_table
-WHERE field1 = :Field1
-AND field2 IN (:FieldIntList)
-AND field3 IN (:FieldStringList)
-`,
-			args: []interface{}{
-				123,
-			},
-			wantQuery: `
-SELECT 1 FROM crazy_table
-WHERE field1 = :Field1
-AND field2 IN (:FieldIntList)
-AND field3 IN (:FieldStringList)
-`,
-			wantArgs: []interface{}{
-				123,
-			},
+		&dataFormat{
+			Field1:  124,
+			Field2:  "e",
+			Field3:  2,
+			Field4:  2,
+			Field5:  2,
+			Field6:  2,
+			Field7:  2,
+			Field8:  2,
+			Field9:  2,
+			Field10: 2,
+			Field11: 2,
+			Field12: 2,
+			Field13: 2,
+			Field14: 2,
 		},
+		&dataFormat{
+			Field1:  125,
+			Field2:  "y",
+			Field3:  3,
+			Field4:  3,
+			Field5:  3,
+			Field6:  3,
+			Field7:  3,
+			Field8:  3,
+			Field9:  3,
+			Field10: 3,
+			Field11: 3,
+			Field12: 3,
+			Field13: 3,
+			Field14: 3,
+		},
+	)
+
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			expandSliceArgs(&tt.query, tt.args...)
-
-			if tt.query != tt.wantQuery {
-				t.Errorf("wrong query\ngot:  %s\nwant: %s", tt.query, tt.wantQuery)
+			var dummy []int
+			_, err := dbmap.Select(&dummy, tt.query, tt.args...)
+			if err != nil {
+				t.Fatal(err)
 			}
 
-			if !reflect.DeepEqual(tt.wantArgs, tt.args) {
-				t.Errorf("wrong args\ngot: %v\nwant: %v", tt.args, tt.wantArgs)
+			if len(dummy) != tt.wantLen {
+				t.Errorf("wrong result count\ngot:  %d\nwant: %d", len(dummy), tt.wantLen)
 			}
 		})
 	}

--- a/db_test.go
+++ b/db_test.go
@@ -91,20 +91,20 @@ AND field12 IN (:FieldIntList)
 	}
 
 	type dataFormat struct {
-		Field1  int
-		Field2  string
-		Field3  uint
-		Field4  uint8
-		Field5  uint16
-		Field6  uint32
-		Field7  uint64
-		Field8  int
-		Field9  int8
-		Field10 int16
-		Field11 int32
-		Field12 int64
-		Field13 float32
-		Field14 float64
+		Field1  int     `db:"field1"`
+		Field2  string  `db:"field2"`
+		Field3  uint    `db:"field3"`
+		Field4  uint8   `db:"field4"`
+		Field5  uint16  `db:"field5"`
+		Field6  uint32  `db:"field6"`
+		Field7  uint64  `db:"field7"`
+		Field8  int     `db:"field8"`
+		Field9  int8    `db:"field9"`
+		Field10 int16   `db:"field10"`
+		Field11 int32   `db:"field11"`
+		Field12 int64   `db:"field12"`
+		Field13 float32 `db:"field13"`
+		Field14 float64 `db:"field14"`
 	}
 
 	dbmap := newDbMap()

--- a/db_test.go
+++ b/db_test.go
@@ -1,0 +1,256 @@
+// Copyright 2012 James Cooper. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+// Package gorp provides a simple way to marshal Go structs to and from
+// SQL databases.  It uses the database/sql package, and should work with any
+// compliant database/sql driver.
+//
+// Source code and project home:
+// https://github.com/go-gorp/gorp
+
+package gorp
+
+import (
+	"reflect"
+	"testing"
+)
+
+type customType1 []string
+
+func (c customType1) ToStringSlice() []string {
+	return []string(c)
+}
+
+type customType2 []int64
+
+func (c customType2) ToInt64Slice() []int64 {
+	return []int64(c)
+}
+
+func TestExpandSliceArgs(t *testing.T) {
+	tests := []struct {
+		description string
+		query       string
+		args        []interface{}
+		wantQuery   string
+		wantArgs    []interface{}
+	}{
+		{
+			description: "it should handle slice placeholders correctly",
+			query: `
+SELECT 1 FROM crazy_table
+WHERE field1 = :Field1
+AND field2 IN (:FieldStringList)
+AND field3 IN (:FieldUIntList)
+AND field4 IN (:FieldUInt8List)
+AND field5 IN (:FieldUInt16List)
+AND field6 IN (:FieldUInt32List)
+AND field7 IN (:FieldUInt64List)
+AND field8 IN (:FieldIntList)
+AND field9 IN (:FieldInt8List)
+AND field10 IN (:FieldInt16List)
+AND field11 IN (:FieldInt32List)
+AND field12 IN (:FieldInt64List)
+AND field13 IN (:FieldFloat32List)
+AND field14 IN (:FieldFloat64List)
+`,
+			args: []interface{}{
+				map[string]interface{}{
+					"Field1":           123,
+					"FieldStringList":  []string{"h", "e", "y"},
+					"FieldUIntList":    []uint{1, 2, 3, 4},
+					"FieldUInt8List":   []uint8{1, 2, 3, 4},
+					"FieldUInt16List":  []uint16{1, 2, 3, 4},
+					"FieldUInt32List":  []uint32{1, 2, 3, 4},
+					"FieldUInt64List":  []uint64{1, 2, 3, 4},
+					"FieldIntList":     []int{1, 2, 3, 4},
+					"FieldInt8List":    []int8{1, 2, 3, 4},
+					"FieldInt16List":   []int16{1, 2, 3, 4},
+					"FieldInt32List":   []int32{1, 2, 3, 4},
+					"FieldInt64List":   []int64{1, 2, 3, 4},
+					"FieldFloat32List": []float32{1, 2, 3, 4},
+					"FieldFloat64List": []float64{1, 2, 3, 4},
+				},
+			},
+			wantQuery: `
+SELECT 1 FROM crazy_table
+WHERE field1 = :Field1
+AND field2 IN (:FieldStringList0,:FieldStringList1,:FieldStringList2)
+AND field3 IN (:FieldUIntList0,:FieldUIntList1,:FieldUIntList2,:FieldUIntList3)
+AND field4 IN (:FieldUInt8List0,:FieldUInt8List1,:FieldUInt8List2,:FieldUInt8List3)
+AND field5 IN (:FieldUInt16List0,:FieldUInt16List1,:FieldUInt16List2,:FieldUInt16List3)
+AND field6 IN (:FieldUInt32List0,:FieldUInt32List1,:FieldUInt32List2,:FieldUInt32List3)
+AND field7 IN (:FieldUInt64List0,:FieldUInt64List1,:FieldUInt64List2,:FieldUInt64List3)
+AND field8 IN (:FieldIntList0,:FieldIntList1,:FieldIntList2,:FieldIntList3)
+AND field9 IN (:FieldInt8List0,:FieldInt8List1,:FieldInt8List2,:FieldInt8List3)
+AND field10 IN (:FieldInt16List0,:FieldInt16List1,:FieldInt16List2,:FieldInt16List3)
+AND field11 IN (:FieldInt32List0,:FieldInt32List1,:FieldInt32List2,:FieldInt32List3)
+AND field12 IN (:FieldInt64List0,:FieldInt64List1,:FieldInt64List2,:FieldInt64List3)
+AND field13 IN (:FieldFloat32List0,:FieldFloat32List1,:FieldFloat32List2,:FieldFloat32List3)
+AND field14 IN (:FieldFloat64List0,:FieldFloat64List1,:FieldFloat64List2,:FieldFloat64List3)
+`,
+			wantArgs: []interface{}{
+				map[string]interface{}{
+					"Field1":            123,
+					"FieldStringList":   []string{"h", "e", "y"},
+					"FieldStringList0":  "h",
+					"FieldStringList1":  "e",
+					"FieldStringList2":  "y",
+					"FieldUIntList":     []uint{1, 2, 3, 4},
+					"FieldUIntList0":    uint(1),
+					"FieldUIntList1":    uint(2),
+					"FieldUIntList2":    uint(3),
+					"FieldUIntList3":    uint(4),
+					"FieldUInt8List":    []uint8{1, 2, 3, 4},
+					"FieldUInt8List0":   uint8(1),
+					"FieldUInt8List1":   uint8(2),
+					"FieldUInt8List2":   uint8(3),
+					"FieldUInt8List3":   uint8(4),
+					"FieldUInt16List":   []uint16{1, 2, 3, 4},
+					"FieldUInt16List0":  uint16(1),
+					"FieldUInt16List1":  uint16(2),
+					"FieldUInt16List2":  uint16(3),
+					"FieldUInt16List3":  uint16(4),
+					"FieldUInt32List":   []uint32{1, 2, 3, 4},
+					"FieldUInt32List0":  uint32(1),
+					"FieldUInt32List1":  uint32(2),
+					"FieldUInt32List2":  uint32(3),
+					"FieldUInt32List3":  uint32(4),
+					"FieldUInt64List":   []uint64{1, 2, 3, 4},
+					"FieldUInt64List0":  uint64(1),
+					"FieldUInt64List1":  uint64(2),
+					"FieldUInt64List2":  uint64(3),
+					"FieldUInt64List3":  uint64(4),
+					"FieldIntList":      []int{1, 2, 3, 4},
+					"FieldIntList0":     int(1),
+					"FieldIntList1":     int(2),
+					"FieldIntList2":     int(3),
+					"FieldIntList3":     int(4),
+					"FieldInt8List":     []int8{1, 2, 3, 4},
+					"FieldInt8List0":    int8(1),
+					"FieldInt8List1":    int8(2),
+					"FieldInt8List2":    int8(3),
+					"FieldInt8List3":    int8(4),
+					"FieldInt16List":    []int16{1, 2, 3, 4},
+					"FieldInt16List0":   int16(1),
+					"FieldInt16List1":   int16(2),
+					"FieldInt16List2":   int16(3),
+					"FieldInt16List3":   int16(4),
+					"FieldInt32List":    []int32{1, 2, 3, 4},
+					"FieldInt32List0":   int32(1),
+					"FieldInt32List1":   int32(2),
+					"FieldInt32List2":   int32(3),
+					"FieldInt32List3":   int32(4),
+					"FieldInt64List":    []int64{1, 2, 3, 4},
+					"FieldInt64List0":   int64(1),
+					"FieldInt64List1":   int64(2),
+					"FieldInt64List2":   int64(3),
+					"FieldInt64List3":   int64(4),
+					"FieldFloat32List":  []float32{1, 2, 3, 4},
+					"FieldFloat32List0": float32(1),
+					"FieldFloat32List1": float32(2),
+					"FieldFloat32List2": float32(3),
+					"FieldFloat32List3": float32(4),
+					"FieldFloat64List":  []float64{1, 2, 3, 4},
+					"FieldFloat64List0": float64(1),
+					"FieldFloat64List1": float64(2),
+					"FieldFloat64List2": float64(3),
+					"FieldFloat64List3": float64(4),
+				},
+			},
+		},
+		{
+			description: "it should handle slice placeholders correctly with custom types",
+			query: `
+SELECT 1 FROM crazy_table
+WHERE field1 = :Field1
+AND field2 IN (:FieldIntList)
+AND field3 IN (:FieldStringList)
+`,
+			args: []interface{}{
+				map[string]interface{}{
+					"Field1":          123,
+					"FieldIntList":    customType2{1, 2, 3, 4},
+					"FieldStringList": customType1{"h", "e", "y"},
+				},
+			},
+			wantQuery: `
+SELECT 1 FROM crazy_table
+WHERE field1 = :Field1
+AND field2 IN (:FieldIntList0,:FieldIntList1,:FieldIntList2,:FieldIntList3)
+AND field3 IN (:FieldStringList0,:FieldStringList1,:FieldStringList2)
+`,
+			wantArgs: []interface{}{
+				map[string]interface{}{
+					"Field1":           123,
+					"FieldIntList":     customType2{1, 2, 3, 4},
+					"FieldIntList0":    int64(1),
+					"FieldIntList1":    int64(2),
+					"FieldIntList2":    int64(3),
+					"FieldIntList3":    int64(4),
+					"FieldStringList":  customType1{"h", "e", "y"},
+					"FieldStringList0": "h",
+					"FieldStringList1": "e",
+					"FieldStringList2": "y",
+				},
+			},
+		},
+		{
+			description: "it should ignore empty slices",
+			query: `
+SELECT 1 FROM crazy_table
+WHERE field1 IN (:FieldIntList)
+`,
+			args: []interface{}{
+				map[string]interface{}{
+					"FieldIntList": []int64{},
+				},
+			},
+			wantQuery: `
+SELECT 1 FROM crazy_table
+WHERE field1 IN (:FieldIntList)
+`,
+			wantArgs: []interface{}{
+				map[string]interface{}{
+					"FieldIntList": []int64{},
+				},
+			},
+		},
+		{
+			description: "it should ignore non-mappers",
+			query: `
+SELECT 1 FROM crazy_table
+WHERE field1 = :Field1
+AND field2 IN (:FieldIntList)
+AND field3 IN (:FieldStringList)
+`,
+			args: []interface{}{
+				123,
+			},
+			wantQuery: `
+SELECT 1 FROM crazy_table
+WHERE field1 = :Field1
+AND field2 IN (:FieldIntList)
+AND field3 IN (:FieldStringList)
+`,
+			wantArgs: []interface{}{
+				123,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			expandSliceArgs(&tt.query, tt.args...)
+
+			if tt.query != tt.wantQuery {
+				t.Errorf("wrong query\ngot:  %s\nwant: %s", tt.query, tt.wantQuery)
+			}
+
+			if !reflect.DeepEqual(tt.wantArgs, tt.args) {
+				t.Errorf("wrong args\ngot: %v\nwant: %v", tt.args, tt.wantArgs)
+			}
+		})
+	}
+}


### PR DESCRIPTION
As discussed in the issue #5, sometimes the caller wants to use a slice in the mapper arguments and the driver does not support it. This patch will convert slices from the mapper into simple values, modifying the SQL to add more placeholders and the mapper, to put each slice item as an unique entry.

This behaviour is optional and by default will be disabled.