### PR TITLE
added maybeExpandNamedQueryAndExec to tx exec to support named params

### DIFF
--- a/gorp_test.go
+++ b/gorp_test.go
@@ -1434,6 +1434,8 @@ func TestTransaction(t *testing.T) {
 }
 
 func TestTransactionExecNamed(t *testing.T) {
+	os.Setenv("GORP_TEST_DSN","root:dev@tcp(db.sunbeam.localhost:3306)/teamworkspaces_shard6")
+	os.Setenv("GORP_TEST_DIALECT","gomysql")
 	dbmap := initDbMap()
 	defer dropAndClose(dbmap)
 	trans, err := dbmap.Begin()
@@ -1448,7 +1450,7 @@ func TestTransactionExecNamed(t *testing.T) {
 		"personID":0,
 		"isPaid": false,
 	}
-	result, err := trans.Exec("INSERT INTO invoice_test (Created, Updated, Memo, PersonID, isPaid) Values(:created, :updated, :memo, :personID, :isPaid)", args)
+	result, err := trans.Exec("INSERT INTO invoice_test (Id, Created, Updated, Memo, PersonID, isPaid) Values(0, :created, :updated, :memo, :personID, :isPaid)", args)
 	if err != nil {
 		panic(err)
 	}
@@ -1471,7 +1473,7 @@ func TestTransactionExecNamed(t *testing.T) {
 	checkMemo("unpaid")
 
 	// exec should still work with ? params
-	result, err = trans.Exec("INSERT INTO invoice_test (Created, Updated, Memo, PersonID, isPaid) Values(?, ?, ?, ?, ?)", 10,15,"paid",0,true)
+	result, err = trans.Exec("INSERT INTO invoice_test (Id, Created, Updated, Memo, PersonID, isPaid) Values(0, ?, ?, ?, ?, ?)", 10,15,"paid",0,true)
 	if err != nil {
 		panic(err)
 	}

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -1434,8 +1434,6 @@ func TestTransaction(t *testing.T) {
 }
 
 func TestTransactionExecNamed(t *testing.T) {
-	os.Setenv("GORP_TEST_DSN","root:dev@tcp(db.sunbeam.localhost:3306)/teamworkspaces_shard6")
-	os.Setenv("GORP_TEST_DIALECT","gomysql")
 	dbmap := initDbMap()
 	defer dropAndClose(dbmap)
 	trans, err := dbmap.Begin()

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -1433,6 +1433,59 @@ func TestTransaction(t *testing.T) {
 	}
 }
 
+func TestTransactionExecNamed(t *testing.T) {
+	dbmap := initDbMap()
+	defer dropAndClose(dbmap)
+	trans, err := dbmap.Begin()
+	if err != nil {
+		panic(err)
+	}
+	// exec should support named params
+	args := map[string]interface{}{
+		"created":100,
+		"updated":200,
+		"memo":"unpaid",
+		"personID":0,
+		"isPaid": false,
+	}
+	result, err := trans.Exec("INSERT INTO invoice_test (Created, Updated, Memo, PersonID, isPaid) Values(:created, :updated, :memo, :personID, :isPaid)", args)
+	if err != nil {
+		panic(err)
+	}
+	id, err := result.LastInsertId()
+	if err != nil {
+		panic(err)
+	}
+	var checkMemo = func(want string) {
+		args := map[string]interface{}{
+			"id":id,
+		}
+		memo, err := trans.SelectStr("select memo from invoice_test where id = :id", args)
+		if err != nil {
+			panic(err)
+		}
+		if memo != want {
+			t.Errorf("%q != %q", want, memo)
+		}
+	}
+	checkMemo("unpaid")
+
+	// exec should still work with ? params
+	result, err = trans.Exec("INSERT INTO invoice_test (Created, Updated, Memo, PersonID, isPaid) Values(?, ?, ?, ?, ?)", 10,15,"paid",0,true)
+	if err != nil {
+		panic(err)
+	}
+	id, err = result.LastInsertId()
+	if err != nil {
+		panic(err)
+	}
+	checkMemo("paid")
+	err = trans.Commit()
+	if err != nil {
+		panic(err)
+	}
+}
+
 func TestSavepoint(t *testing.T) {
 	dbmap := initDbMap()
 	defer dropAndClose(dbmap)

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -1434,12 +1434,16 @@ func TestTransaction(t *testing.T) {
 }
 
 func TestTransactionExecNamed(t *testing.T) {
+	if os.Getenv("GORP_TEST_DIALECT") == "postgres" {
+		return
+	}
 	dbmap := initDbMap()
 	defer dropAndClose(dbmap)
 	trans, err := dbmap.Begin()
 	if err != nil {
 		panic(err)
 	}
+	defer trans.Rollback()
 	// exec should support named params
 	args := map[string]interface{}{
 		"created":100,
@@ -1448,7 +1452,8 @@ func TestTransactionExecNamed(t *testing.T) {
 		"personID":0,
 		"isPaid": false,
 	}
-	result, err := trans.Exec("INSERT INTO invoice_test (Id, Created, Updated, Memo, PersonID, isPaid) Values(0, :created, :updated, :memo, :personID, :isPaid)", args)
+
+	result, err := trans.Exec(`INSERT INTO invoice_test (Created, Updated, Memo, PersonId, IsPaid) Values(:created, :updated, :memo, :personID, :isPaid)`, args)
 	if err != nil {
 		panic(err)
 	}
@@ -1471,7 +1476,7 @@ func TestTransactionExecNamed(t *testing.T) {
 	checkMemo("unpaid")
 
 	// exec should still work with ? params
-	result, err = trans.Exec("INSERT INTO invoice_test (Id, Created, Updated, Memo, PersonID, isPaid) Values(0, ?, ?, ?, ?, ?)", 10,15,"paid",0,true)
+	result, err = trans.Exec(`INSERT INTO invoice_test (Created, Updated, Memo, PersonId, IsPaid) Values(?, ?, ?, ?, ?)`, 10,15,"paid",0,true)
 	if err != nil {
 		panic(err)
 	}
@@ -1480,6 +1485,55 @@ func TestTransactionExecNamed(t *testing.T) {
 		panic(err)
 	}
 	checkMemo("paid")
+	err = trans.Commit()
+	if err != nil {
+		panic(err)
+	}
+}
+
+func TestTransactionExecNamedPostgres(t *testing.T) {
+	if os.Getenv("GORP_TEST_DIALECT") != "postgres" {
+		return
+	}
+	dbmap := initDbMap()
+	defer dropAndClose(dbmap)
+	trans, err := dbmap.Begin()
+	if err != nil {
+		panic(err)
+	}
+	// exec should support named params
+	args := map[string]interface{}{
+		"created":100,
+		"updated":200,
+		"memo":"zzTest",
+		"personID":0,
+		"isPaid": false,
+	}
+	_, err = trans.Exec(`INSERT INTO invoice_test ("Created", "Updated", "Memo", "PersonId", "IsPaid") Values(:created, :updated, :memo, :personID, :isPaid)`, args)
+	if err != nil {
+		panic(err)
+	}
+	var checkMemo = func(want string) {
+		args := map[string]interface{}{
+			"memo":want,
+		}
+		memo, err := trans.SelectStr(`select "Memo" from invoice_test where "Memo" = :memo`, args)
+		if err != nil {
+			panic(err)
+		}
+		if memo != want {
+			t.Errorf("%q != %q", want, memo)
+		}
+	}
+	checkMemo("zzTest")
+
+	// exec should still work with ? params
+	_, err = trans.Exec(`INSERT INTO invoice_test ("Created", "Updated", "Memo", "PersonId", "IsPaid") Values($1, $2, $3, $4, $5)`, 10,15,"yyTest",0,true)
+
+	if err != nil {
+		panic(err)
+	}
+	checkMemo("yyTest")
 	err = trans.Commit()
 	if err != nil {
 		panic(err)

--- a/transaction.go
+++ b/transaction.go
@@ -71,7 +71,7 @@ func (t *Transaction) Exec(query string, args ...interface{}) (sql.Result, error
 		now := time.Now()
 		defer t.dbmap.trace(now, query, args...)
 	}
-	return exec(t, query, args...)
+	return maybeExpandNamedQueryAndExec(t, query, args...)
 }
 
 // SelectInt is a convenience wrapper around the gorp.SelectInt function.


### PR DESCRIPTION
[Issue](https://github.com/go-gorp/gorp/issues/378)

This adds support for named parameters to transaction based exec statements. This then ensures, as per the method comment, that tx.exec *'Exec has the same behavior as DbMap.Exec(), but runs in a transaction.'*

A benefit of this is being able to remove many ? placeholders which could be required for more complex inserts etc and make the sql statements themselves more readable.