### PR TITLE
Support for readonly transient field #394

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,13 +261,17 @@ type Person struct {
 //   table.ColMap("Id").Rename("product_id")
 //   table.ColMap("Price").Rename("unit_price")
 //   table.ColMap("IgnoreMe").SetTransient(true)
+//   table.ColMap("IgnoreWrite").Rename("ignore_write").SetTransient(true)
 //
 // You can optionally declare the field to be a primary key and/or autoincrement
+// The readonly fields are transient but available for mapping on reads (e.g. this 
+// field may be a computed property)
 //
 type Product struct {
-    Id         int64     `db:"product_id, primarykey, autoincrement"`
-    Price      int64     `db:"unit_price"`
-    IgnoreMe   string    `db:"-"`
+    Id           int64     `db:"product_id, primarykey, autoincrement"`
+    Price        int64     `db:"unit_price"`
+    IgnoreMe     string    `db:"-"`
+    IgnoreWrite  string    `db:"ignore_write, readonly"`
 }
 ```
 

--- a/db.go
+++ b/db.go
@@ -320,6 +320,7 @@ func (m *DbMap) readStructColumns(t reflect.Type) (cols []*ColumnMap, primaryKey
 			var isAuto bool
 			var isPK bool
 			var isNotNull bool
+			var isReadOnly bool
 			for _, argString := range cArguments[1:] {
 				argString = strings.TrimSpace(argString)
 				arg := strings.SplitN(argString, ":", 2)
@@ -349,6 +350,8 @@ func (m *DbMap) readStructColumns(t reflect.Type) (cols []*ColumnMap, primaryKey
 					isAuto = true
 				case "notnull":
 					isNotNull = true
+				case "readonly":
+					isReadOnly = true
 				default:
 					panic(fmt.Sprintf("Unrecognized tag option for field %v: %v", f.Name, arg))
 				}
@@ -390,7 +393,7 @@ func (m *DbMap) readStructColumns(t reflect.Type) (cols []*ColumnMap, primaryKey
 			cm := &ColumnMap{
 				ColumnName:   columnName,
 				DefaultValue: defaultValue,
-				Transient:    columnName == "-",
+				Transient:    columnName == "-" || isReadOnly,
 				fieldName:    f.Name,
 				gotype:       gotype,
 				isPK:         isPK,


### PR DESCRIPTION
The issue #394 raises a very typical use case for fields that are not physically present in the table as a column, however, they are computed on reads.

For example, if I want to have a `full_name` property populated in ` type User struct { f_name string, s_name string, full_name string}` for a table `User = { f_name, s_name }` the query
```
dbMap.SelectOne(&user, 
"select f_name, s_name, concat(f_name, s_name) full_name" from user...)
```
will successfully map the result as expected, however, the **inserts will fail**.

If I ignore `full_name` field via `db:"-"`, inserts will work as expected, but **reads will raise `NoFieldInTypeError`**. Despite this is a "non-fatal error", it breaks the old codebase that expects no errors.

This change introduces a new field Tag `"readonly"` that behaves exactly as a transient field (`db.go#readStructColumns` maps such column to `ColumnMap` with `Transient=true`) , except `gorp.go#columnToFieldIndex` won't skip it for mapping select results.

Tested locally with postgres db.
