### PR TITLE
WIP: Added an "upsert" mechanism and associated unittests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
 
 services:
 - mysql
-- postgres
+- postgresql
 - sqlite3
 
 env:

--- a/db.go
+++ b/db.go
@@ -616,8 +616,8 @@ func (m *DbMap) UpdateColumns(filter ColumnFilter, list ...interface{}) (int64, 
 // before/after the upsert if the interface defines them.
 //
 // Panics if any interface in the list has not been registered with AddTable
-func (m *DbMap) Upsert(list ...interface{}) error {
-	return upsert(m, m, list...)
+func (m *DbMap) Upsert(updateOnConflict bool, list ...interface{}) error {
+	return upsert(m, m, updateOnConflict, list...)
 }
 
 // Delete runs a SQL DELETE statement for each element in list.  List

--- a/db.go
+++ b/db.go
@@ -603,6 +603,23 @@ func (m *DbMap) UpdateColumns(filter ColumnFilter, list ...interface{}) (int64, 
 	return update(m, m, filter, list...)
 }
 
+// Upsert runs a SQL statement specific to each dialog which either
+// inserts or updates each element in the list according to whether or
+// not it is already in the database (update) or is not yet in the
+// database (insert). List items must be pointers.
+//
+// Only TableMaps without auto-incrementing primary keys are
+// allowed. Any interface whose TableMap has an auto-increment primary
+// key will result in an error.
+//
+// The hook functions PreUpsert() and/or PostUpsert() will be executed
+// before/after the upsert if the interface defines them.
+//
+// Panics if any interface in the list has not been registered with AddTable
+func (m *DbMap) Upsert(list ...interface{}) error {
+	return upsert(m, m, list...)
+}
+
 // Delete runs a SQL DELETE statement for each element in list.  List
 // items must be pointers.
 //

--- a/dialect.go
+++ b/dialect.go
@@ -78,6 +78,12 @@ type Dialect interface {
 	IfTableNotExists(command, schema, table string) string
 }
 
+type Upsertter interface {
+	UpsertStatementDoUpdate() string
+
+	UpsertStatementDoNothing() string
+}
+
 // IntegerAutoIncrInserter is implemented by dialects that can perform
 // inserts with automatically incremented integer primary keys.  If
 // the dialect can handle automatic assignment of more than just

--- a/dialect.go
+++ b/dialect.go
@@ -68,6 +68,10 @@ type Dialect interface {
 	// table - The table name
 	QuotedTableForQuery(schema string, table string) string
 
+	// SupportsUpsert returns true if gorp includes dialect-specific support
+	// for the upsert (insert or update) statement.
+	SupportsUpsert() bool
+
 	// Existence clause for table creation / deletion
 	IfSchemaNotExists(command, schema string) string
 	IfTableExists(command, schema, table string) string

--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -163,6 +163,10 @@ func (d MySQLDialect) QuotedTableForQuery(schema string, table string) string {
 	return schema + "." + d.QuoteField(table)
 }
 
+func (d MySQLDialect) SupportsUpsert() bool {
+	return true
+}
+
 func (d MySQLDialect) IfSchemaNotExists(command, schema string) string {
 	return fmt.Sprintf("%s if not exists", command)
 }

--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -178,3 +178,11 @@ func (d MySQLDialect) IfTableExists(command, schema, table string) string {
 func (d MySQLDialect) IfTableNotExists(command, schema, table string) string {
 	return fmt.Sprintf("%s if not exists", command)
 }
+
+func (d MySQLDialect) UpsertStatementDoUpdate() string {
+	return " on duplicate key update"
+}
+
+func (d MySQLDialect) UpsertStatementDoNothing() string {
+	return d.UpsertStatementDoUpdate() // MySQL doesn't support do nothing
+}

--- a/dialect_oracle.go
+++ b/dialect_oracle.go
@@ -125,6 +125,10 @@ func (d OracleDialect) QuoteField(f string) string {
 	return `"` + strings.ToUpper(f) + `"`
 }
 
+func (d OracleDialect) SupportsUpsert() bool {
+	return false
+}
+
 func (d OracleDialect) QuotedTableForQuery(schema string, table string) string {
 	if strings.TrimSpace(schema) == "" {
 		return d.QuoteField(table)

--- a/dialect_postgres.go
+++ b/dialect_postgres.go
@@ -143,6 +143,10 @@ func (d PostgresDialect) QuotedTableForQuery(schema string, table string) string
 	return schema + "." + d.QuoteField(table)
 }
 
+func (d PostgresDialect) SupportsUpsert() bool {
+	return true
+}
+
 func (d PostgresDialect) IfSchemaNotExists(command, schema string) string {
 	return fmt.Sprintf("%s if not exists", command)
 }

--- a/dialect_postgres.go
+++ b/dialect_postgres.go
@@ -158,3 +158,11 @@ func (d PostgresDialect) IfTableExists(command, schema, table string) string {
 func (d PostgresDialect) IfTableNotExists(command, schema, table string) string {
 	return fmt.Sprintf("%s if not exists", command)
 }
+
+func (d PostgresDialect) UpsertStatementDoUpdate() string {
+	return " on conflict do update"
+}
+
+func (d PostgresDialect) UpsertStatementDoNothing() string {
+	return " on conflict do nothing"
+}

--- a/dialect_sqlite.go
+++ b/dialect_sqlite.go
@@ -106,6 +106,10 @@ func (d SqliteDialect) QuotedTableForQuery(schema string, table string) string {
 	return d.QuoteField(table)
 }
 
+func (d SqliteDialect) SupportsUpsert() bool {
+	return false
+}
+
 func (d SqliteDialect) IfSchemaNotExists(command, schema string) string {
 	return fmt.Sprintf("%s if not exists", command)
 }

--- a/dialect_sqlserver.go
+++ b/dialect_sqlserver.go
@@ -123,6 +123,10 @@ func (d SqlServerDialect) QuotedTableForQuery(schema string, table string) strin
 	return d.QuoteField(schema) + "." + d.QuoteField(table)
 }
 
+func (d SqlServerDialect) SupportsUpsert() bool {
+	return false
+}
+
 func (d SqlServerDialect) QuerySuffix() string { return ";" }
 
 func (d SqlServerDialect) IfSchemaNotExists(command, schema string) string {

--- a/gorp.go
+++ b/gorp.go
@@ -101,7 +101,7 @@ type SqlExecutor interface {
 	Get(i interface{}, keys ...interface{}) (interface{}, error)
 	Insert(list ...interface{}) error
 	Update(list ...interface{}) (int64, error)
-	Upsert(list ...interface{}) error
+	Upsert(updateOnConflict bool, list ...interface{}) error
 	Delete(list ...interface{}) (int64, error)
 	Exec(query string, args ...interface{}) (sql.Result, error)
 	Select(i interface{}, query string, args ...interface{}) ([]interface{}, error)
@@ -618,7 +618,7 @@ func insert(m *DbMap, exec SqlExecutor, list ...interface{}) error {
 	return nil
 }
 
-func upsert(m *DbMap, exec SqlExecutor, list ...interface{}) error {
+func upsert(m *DbMap, exec SqlExecutor, updateOnConflict bool, list ...interface{}) error {
 	for _, ptr := range list {
 		table, elem, err := m.tableForPointer(ptr, false)
 		if err != nil {
@@ -633,7 +633,7 @@ func upsert(m *DbMap, exec SqlExecutor, list ...interface{}) error {
 			}
 		}
 
-		bi, err := table.bindUpsert(elem)
+		bi, err := table.bindUpsert(elem, updateOnConflict)
 		if err != nil {
 			return err
 		}

--- a/gorp.go
+++ b/gorp.go
@@ -637,7 +637,7 @@ func upsert(m *DbMap, exec SqlExecutor, list ...interface{}) error {
 		if err != nil {
 			return err
 		}
-		fmt.Println(bi.query)
+
 		_, err = exec.Exec(bi.query, bi.args...)
 		if err != nil {
 			return err

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -383,12 +383,12 @@ func (p *Person) PostUpdate(s gorp.SqlExecutor) error {
 	return nil
 }
 
-func (p *Person) PreUpsert(s SqlExecutor) error {
+func (p *Person) PreUpsert(s gorp.SqlExecutor) error {
 	p.FName = "preupsert"
 	return nil
 }
 
-func (p *Person) PostUpsert(s SqlExecutor) error {
+func (p *Person) PostUpsert(s gorp.SqlExecutor) error {
 	p.LName = "postupsert"
 	return nil
 }
@@ -2807,7 +2807,7 @@ func _update(dbmap *gorp.DbMap, list ...interface{}) int64 {
 	return count
 }
 
-func _upsert(dbmap *DbMap, list ...interface{}) {
+func _upsert(dbmap *gorp.DbMap, list ...interface{}) {
 	err := dbmap.Upsert(list...)
 	if err != nil {
 		panic(err)

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -1465,11 +1465,11 @@ func TestTransactionExecNamed(t *testing.T) {
 	defer trans.Rollback()
 	// exec should support named params
 	args := map[string]interface{}{
-		"created":100,
-		"updated":200,
-		"memo":"unpaid",
-		"personID":0,
-		"isPaid": false,
+		"created":  100,
+		"updated":  200,
+		"memo":     "unpaid",
+		"personID": 0,
+		"isPaid":   false,
 	}
 
 	result, err := trans.Exec(`INSERT INTO invoice_test (Created, Updated, Memo, PersonId, IsPaid) Values(:created, :updated, :memo, :personID, :isPaid)`, args)
@@ -1482,7 +1482,7 @@ func TestTransactionExecNamed(t *testing.T) {
 	}
 	var checkMemo = func(want string) {
 		args := map[string]interface{}{
-			"id":id,
+			"id": id,
 		}
 		memo, err := trans.SelectStr("select memo from invoice_test where id = :id", args)
 		if err != nil {
@@ -1495,7 +1495,7 @@ func TestTransactionExecNamed(t *testing.T) {
 	checkMemo("unpaid")
 
 	// exec should still work with ? params
-	result, err = trans.Exec(`INSERT INTO invoice_test (Created, Updated, Memo, PersonId, IsPaid) Values(?, ?, ?, ?, ?)`, 10,15,"paid",0,true)
+	result, err = trans.Exec(`INSERT INTO invoice_test (Created, Updated, Memo, PersonId, IsPaid) Values(?, ?, ?, ?, ?)`, 10, 15, "paid", 0, true)
 	if err != nil {
 		panic(err)
 	}
@@ -1522,11 +1522,11 @@ func TestTransactionExecNamedPostgres(t *testing.T) {
 	}
 	// exec should support named params
 	args := map[string]interface{}{
-		"created":100,
-		"updated":200,
-		"memo":"zzTest",
-		"personID":0,
-		"isPaid": false,
+		"created":  100,
+		"updated":  200,
+		"memo":     "zzTest",
+		"personID": 0,
+		"isPaid":   false,
 	}
 	_, err = trans.Exec(`INSERT INTO invoice_test ("Created", "Updated", "Memo", "PersonId", "IsPaid") Values(:created, :updated, :memo, :personID, :isPaid)`, args)
 	if err != nil {
@@ -1534,7 +1534,7 @@ func TestTransactionExecNamedPostgres(t *testing.T) {
 	}
 	var checkMemo = func(want string) {
 		args := map[string]interface{}{
-			"memo":want,
+			"memo": want,
 		}
 		memo, err := trans.SelectStr(`select "Memo" from invoice_test where "Memo" = :memo`, args)
 		if err != nil {
@@ -1547,7 +1547,7 @@ func TestTransactionExecNamedPostgres(t *testing.T) {
 	checkMemo("zzTest")
 
 	// exec should still work with ? params
-	_, err = trans.Exec(`INSERT INTO invoice_test ("Created", "Updated", "Memo", "PersonId", "IsPaid") Values($1, $2, $3, $4, $5)`, 10,15,"yyTest",0,true)
+	_, err = trans.Exec(`INSERT INTO invoice_test ("Created", "Updated", "Memo", "PersonId", "IsPaid") Values($1, $2, $3, $4, $5)`, 10, 15, "yyTest", 0, true)
 
 	if err != nil {
 		panic(err)
@@ -1709,7 +1709,7 @@ func TestUpsert(t *testing.T) {
 
 	// First, try an upsert with an auto-increment table.
 	inv := &Invoice{0, 100, 200, "first order", 0, true}
-	if err := dbmap.Upsert(inv); err == nil {
+	if err := dbmap.Upsert(inv, false); err == nil {
 		t.Error("expected failure trying to upsert a row to an auto-increment table")
 	}
 
@@ -2808,7 +2808,7 @@ func _update(dbmap *gorp.DbMap, list ...interface{}) int64 {
 }
 
 func _upsert(dbmap *gorp.DbMap, list ...interface{}) {
-	err := dbmap.Upsert(list...)
+	err := dbmap.Upsert(list, false)
 	if err != nil {
 		panic(err)
 	}

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -383,6 +383,16 @@ func (p *Person) PostUpdate(s gorp.SqlExecutor) error {
 	return nil
 }
 
+func (p *Person) PreUpsert(s SqlExecutor) error {
+	p.FName = "preupsert"
+	return nil
+}
+
+func (p *Person) PostUpsert(s SqlExecutor) error {
+	p.LName = "postupsert"
+	return nil
+}
+
 func (p *Person) PreDelete(s gorp.SqlExecutor) error {
 	p.FName = "predelete"
 	return nil
@@ -1378,6 +1388,15 @@ func TestHooks(t *testing.T) {
 		t.Errorf("p1.PostUpdate() didn't run: %v", p1)
 	}
 
+	if dbmap.Dialect.SupportsUpsert() {
+		_upsert(dbmap, p1)
+		if p1.FName != "preupsert" {
+			t.Errorf("p1.PreUpsert() didn't run: %v", p1)
+		} else if p1.LName != "postupsert" {
+			t.Errorf("p1.PostUpsert() didn't run: %v", p1)
+		}
+	}
+
 	var persons []*Person
 	bindVar := dbmap.Dialect.BindVar(0)
 	rawSelect(dbmap, &persons, "select * from person_test where "+columnName(dbmap, Person{}, "Id")+" = "+bindVar, p1.Id)
@@ -1678,6 +1697,46 @@ func testCrudInternal(t *testing.T, dbmap *gorp.DbMap, val testable) {
 	val2 = _get(dbmap, val, val.GetId())
 	if val2 != nil {
 		t.Errorf("Found invoice with id: %d after Delete()", val.GetId())
+	}
+}
+
+func TestUpsert(t *testing.T) {
+	dbmap := initDbMap()
+	defer dropAndClose(dbmap)
+	if !dbmap.Dialect.SupportsUpsert() {
+		return
+	}
+
+	// First, try an upsert with an auto-increment table.
+	inv := &Invoice{0, 100, 200, "first order", 0, true}
+	if err := dbmap.Upsert(inv); err == nil {
+		t.Error("expected failure trying to upsert a row to an auto-increment table")
+	}
+
+	oinv := &OverriddenInvoice{
+		Invoice: *inv,
+		Id:      "1",
+	}
+
+	// Upsert for insert.
+	_upsert(dbmap, oinv)
+
+	// SELECT row to verify insert.
+	obj := _get(dbmap, OverriddenInvoice{}, oinv.Id)
+	oinv2 := obj.(*OverriddenInvoice)
+	if !reflect.DeepEqual(oinv, oinv2) {
+		t.Errorf("%v != %v", oinv, oinv2)
+	}
+
+	// Upsert again with modifications.
+	oinv.Memo = "second order"
+	oinv.Created = 999
+	oinv.Updated = 11111
+	_upsert(dbmap, oinv)
+	obj = _get(dbmap, OverriddenInvoice{}, oinv.Id)
+	oinv2 = obj.(*OverriddenInvoice)
+	if !reflect.DeepEqual(oinv, oinv2) {
+		t.Errorf("%v != %v", oinv, oinv2)
 	}
 }
 
@@ -2746,6 +2805,13 @@ func _update(dbmap *gorp.DbMap, list ...interface{}) int64 {
 		panic(err)
 	}
 	return count
+}
+
+func _upsert(dbmap *DbMap, list ...interface{}) {
+	err := dbmap.Upsert(list...)
+	if err != nil {
+		panic(err)
+	}
 }
 
 func _updateColumns(dbmap *gorp.DbMap, filter gorp.ColumnFilter, list ...interface{}) int64 {

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -1709,7 +1709,7 @@ func TestUpsert(t *testing.T) {
 
 	// First, try an upsert with an auto-increment table.
 	inv := &Invoice{0, 100, 200, "first order", 0, true}
-	if err := dbmap.Upsert(inv, false); err == nil {
+	if err := dbmap.Upsert(true, inv, false); err == nil {
 		t.Error("expected failure trying to upsert a row to an auto-increment table")
 	}
 
@@ -2808,7 +2808,7 @@ func _update(dbmap *gorp.DbMap, list ...interface{}) int64 {
 }
 
 func _upsert(dbmap *gorp.DbMap, list ...interface{}) {
-	err := dbmap.Upsert(list, false)
+	err := dbmap.Upsert(true, list, false)
 	if err != nil {
 		panic(err)
 	}

--- a/hooks.go
+++ b/hooks.go
@@ -33,6 +33,11 @@ type HasPostInsert interface {
 	PostInsert(SqlExecutor) error
 }
 
+// PostUpsert() will be executed after an upsert statement.
+type HasPostUpsert interface {
+	PostUpsert(SqlExecutor) error
+}
+
 // HasPreDelete provides PreDelete() which will be executed before the DELETE statement.
 type HasPreDelete interface {
 	PreDelete(SqlExecutor) error
@@ -46,4 +51,9 @@ type HasPreUpdate interface {
 // HasPreInsert provides PreInsert() which will be executed before INSERT statement.
 type HasPreInsert interface {
 	PreInsert(SqlExecutor) error
+}
+
+// PreUpsert() will be executed before an upsert statement.
+type HasPreUpsert interface {
+	PreUpsert(SqlExecutor) error
 }

--- a/table.go
+++ b/table.go
@@ -32,6 +32,7 @@ type TableMap struct {
 	version        *ColumnMap
 	insertPlan     bindPlan
 	updatePlan     bindPlan
+	upsertPlan     bindPlan
 	deletePlan     bindPlan
 	getPlan        bindPlan
 	dbmap          *DbMap
@@ -43,6 +44,7 @@ type TableMap struct {
 func (t *TableMap) ResetSql() {
 	t.insertPlan = bindPlan{}
 	t.updatePlan = bindPlan{}
+	t.upsertPlan = bindPlan{}
 	t.deletePlan = bindPlan{}
 	t.getPlan = bindPlan{}
 }

--- a/table_bindings.go
+++ b/table_bindings.go
@@ -253,9 +253,9 @@ func (t *TableMap) bindUpsert(elem reflect.Value) (bindInstance, error) {
 			// TODO(spencer.kimball@gmail.com): there are ways to handle
 			// auto increment columns with upsert in MySQL, and no doubt other
 			// databases as well.
-			if col.isAutoIncr {
-				return bindInstance{}, fmt.Errorf("gorp: cannot upsert to tables with autoincrement field %q", col.fieldName)
-			}
+			//if col.isAutoIncr {
+			//	return bindInstance{}, fmt.Errorf("gorp: cannot upsert to tables with autoincrement field %q", col.fieldName)
+			//}
 			if !col.Transient {
 				if !first {
 					s.WriteString(",")

--- a/table_bindings.go
+++ b/table_bindings.go
@@ -253,9 +253,9 @@ func (t *TableMap) bindUpsert(elem reflect.Value, updateOnConflict bool) (bindIn
 			// TODO(spencer.kimball@gmail.com): there are ways to handle
 			// auto increment columns with upsert in MySQL, and no doubt other
 			// databases as well.
-			//if col.isAutoIncr {
-			//	return bindInstance{}, fmt.Errorf("gorp: cannot upsert to tables with autoincrement field %q", col.fieldName)
-			//}
+			if col.isAutoIncr {
+				return bindInstance{}, fmt.Errorf("gorp: cannot upsert to tables with autoincrement field %q", col.fieldName)
+			}
 			if !col.Transient {
 				if !first {
 					s.WriteString(",")

--- a/table_bindings.go
+++ b/table_bindings.go
@@ -237,6 +237,7 @@ func (t *TableMap) bindUpsert(elem reflect.Value) (bindInstance, error) {
 	if !t.dbmap.Dialect.SupportsUpsert() {
 		return bindInstance{}, fmt.Errorf("SQL dialect doesn't have gorp support for upsert; consider adding it!")
 	}
+
 	plan := t.upsertPlan
 	if plan.query == "" {
 		plan.autoIncrIdx = -1

--- a/transaction.go
+++ b/transaction.go
@@ -18,7 +18,7 @@ import (
 )
 
 // Transaction represents a database transaction.
-// Insert/Update/Delete/Get/Exec operations will be run in the context
+// Insert/Update/Upsert/Delete/Get/Exec operations will be run in the context
 // of that transaction.  Transactions should be terminated with
 // a call to Commit() or Rollback()
 type Transaction struct {
@@ -48,6 +48,11 @@ func (t *Transaction) Update(list ...interface{}) (int64, error) {
 // UpdateColumns had the same behavior as DbMap.UpdateColumns(), but runs in a transaction.
 func (t *Transaction) UpdateColumns(filter ColumnFilter, list ...interface{}) (int64, error) {
 	return update(t.dbmap, t, filter, list...)
+}
+
+// Upsert has the same behavior as DbMap.Upsert(), but runs in a transaction.
+func (t *Transaction) Upsert(list ...interface{}) error {
+	return upsert(t.dbmap, t, list...)
 }
 
 // Delete has the same behavior as DbMap.Delete(), but runs in a transaction.

--- a/transaction.go
+++ b/transaction.go
@@ -51,8 +51,8 @@ func (t *Transaction) UpdateColumns(filter ColumnFilter, list ...interface{}) (i
 }
 
 // Upsert has the same behavior as DbMap.Upsert(), but runs in a transaction.
-func (t *Transaction) Upsert(list ...interface{}) error {
-	return upsert(t.dbmap, t, list...)
+func (t *Transaction) Upsert(updateOnConflict bool, list ...interface{}) error {
+	return upsert(t.dbmap, t, updateOnConflict, list...)
 }
 
 // Delete has the same behavior as DbMap.Delete(), but runs in a transaction.


### PR DESCRIPTION
Continues from #174 by @spencerkimball.

Upsert is a portmanteau for "update" and "insert". It allows a single
statement to either insert if the primary key is not present or update
if it is present.

The current implementation is MySQL specific and will return an error
for any other dialect. Support for this feature varies widely amongst
database vendors as it's not part of the SQL ansi standard. For MySQL,
we use the "ON DUPLICATE KEY UPDATE ..." suffix to insert statements.