### PR TITLE
fix import path in testing

### DIFF
--- a/dialect_mysql_test.go
+++ b/dialect_mysql_test.go
@@ -14,10 +14,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-gorp/gorp/v3"
 	"github.com/poy/onpar"
 	"github.com/poy/onpar/expect"
 	"github.com/poy/onpar/matchers"
-	"github.com/go-gorp/gorp"
 )
 
 func TestMySQLDialect(t *testing.T) {

--- a/dialect_postgres_test.go
+++ b/dialect_postgres_test.go
@@ -12,10 +12,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-gorp/gorp/v3"
 	"github.com/poy/onpar"
 	"github.com/poy/onpar/expect"
 	"github.com/poy/onpar/matchers"
-	"github.com/go-gorp/gorp"
 )
 
 func TestPostgresDialect(t *testing.T) {

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,7 @@ golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 google.golang.org/appengine v1.6.5 h1:tycE03LOZYQNhDpS27tcQdAzLCVMaj7QT2SXxebnpCM=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-gorp/gorp"
+	"github.com/go-gorp/gorp/v3"
 
 	_ "github.com/go-sql-driver/mysql"
 	_ "github.com/lib/pq"


### PR DESCRIPTION
Without this change, the test will run with gorp v2.2.0.