### PR TITLE
Add FatalError func to avoid double negative

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -20,12 +20,17 @@ func (err *NoFieldInTypeError) Error() string {
 	return fmt.Sprintf("gorp: no fields %+v in type %s", err.MissingColNames, err.TypeName)
 }
 
-// returns true if the error is non-fatal (ie, we shouldn't immediately return)
-func NonFatalError(err error) bool {
+// returns true if the error is fatal (ie, we should immediately return)
+func FatalError(err error) bool {
 	switch err.(type) {
 	case *NoFieldInTypeError:
-		return true
-	default:
 		return false
+	default:
+		return true
 	}
+}
+
+// returns true if the error is non-fatal (ie, we shouldn't immediately return)
+func NonFatalError(err error) bool {
+	return !FatalError(err)
 }

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -2232,7 +2232,7 @@ func TestSelectTooManyCols(t *testing.T) {
 	var p3 FNameOnly
 	err := dbmap.SelectOne(&p3, "select * from person_test where "+columnName(dbmap, Person{}, "Id")+"=:Id", params)
 	if err != nil {
-		if !gorp.NonFatalError(err) {
+		if gorp.FatalError(err) {
 			t.Error(err)
 		}
 	} else {
@@ -2246,7 +2246,7 @@ func TestSelectTooManyCols(t *testing.T) {
 	var pSlice []FNameOnly
 	_, err = dbmap.Select(&pSlice, "select * from person_test order by "+columnName(dbmap, Person{}, "FName")+" asc")
 	if err != nil {
-		if !gorp.NonFatalError(err) {
+		if gorp.FatalError(err) {
 			t.Error(err)
 		}
 	} else {

--- a/select.go
+++ b/select.go
@@ -110,7 +110,7 @@ func SelectOne(m *DbMap, e SqlExecutor, holder interface{}, query string, args .
 
 		list, err := hookedselect(m, e, holder, query, args...)
 		if err != nil {
-			if !NonFatalError(err) { // FIXME: double negative, rename NonFatalError to FatalError
+			if FatalError(err) {
 				return err
 			}
 			nonFatalErr = err
@@ -178,7 +178,7 @@ func hookedselect(m *DbMap, exec SqlExecutor, i interface{}, query string,
 
 	list, err := rawselect(m, exec, i, query, args...)
 	if err != nil {
-		if !NonFatalError(err) {
+		if FatalError(err) {
 			return nil, err
 		}
 		nonFatalErr = err
@@ -271,7 +271,7 @@ func rawselect(m *DbMap, exec SqlExecutor, i interface{}, query string,
 	if intoStruct {
 		colToFieldIndex, err = columnToFieldIndex(m, t, tableName, cols)
 		if err != nil {
-			if !NonFatalError(err) {
+			if FatalError(err) {
 				return nil, err
 			}
 			nonFatalErr = err


### PR DESCRIPTION
I added `FatalError` function to avoid double negative like `!NonFatalError(err)` as you can see in the FIXME comment.
I didn't delete existing `NonFatalError` function to keep backward compatibility.
How about this change?