### PR TITLE
add WithDbMapContext

### DIFF
--- a/db.go
+++ b/db.go
@@ -117,6 +117,14 @@ func (m *DbMap) dynamicTableMap() map[string]*TableMap {
 	return m.tablesDynamic
 }
 
+// WithDbMapContext is like WithContext, but returns the DbMap instead of a generic SqlExecutor
+func (m *DbMap) WithDbMapContext(ctx context.Context) DbMap {
+	copy := &DbMap{}
+	*copy = *m
+	copy.ctx = ctx
+	return *copy
+}
+
 func (m *DbMap) WithContext(ctx context.Context) SqlExecutor {
 	copy := &DbMap{}
 	*copy = *m


### PR DESCRIPTION
fixes https://github.com/go-gorp/gorp/issues/437

currently you cannot set context on a `DbMap` without transforming it into the more generic `SqlExecutor`. sometimes you want to add context while retaining the specificity of the `DbMap`, this new function makes that possible without casting.