### PR TITLE
Make query logging more extensible

### DIFF
--- a/db.go
+++ b/db.go
@@ -873,8 +873,7 @@ func (m *DbMap) trace(started time.Time, query string, args ...interface{}) {
 	}
 
 	if m.logger != nil {
-		var margs = argsString(args...)
-		m.logger.Printf("%s%s [%s] (%v)", m.logPrefix, query, margs, (time.Now().Sub(started)))
+		m.logger.Printf("%s (%v) %s [%v]", m.logPrefix, (time.Now().Sub(started)), query, args)
 	}
 }
 


### PR DESCRIPTION
My use-case is that I want to replace placeholders with specific data. If you set custom logger, currently the problem is that logger receives injected data as a string. This is not very interoperable. I don't want to deal with all possible types by parsing stringified arguments. 

This PR passes original arguments to the logger